### PR TITLE
Preserving CSS escape characters

### DIFF
--- a/core/pdfmaker/pdfmaker.rb
+++ b/core/pdfmaker/pdfmaker.rb
@@ -71,6 +71,9 @@ FileUtils.mv("#{Metadata.pisbn}.pdf","#{Bkmkr::Paths.done_dir}/#{Metadata.pisbn}
 docpdf = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "layout", "docraptor.html")
 File.open(docpdf, "w") {|file| file.puts pdf_html}
 
+doccss = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "layout", "docraptor.css")
+File.open(docpdf, "w") {|file| file.puts embedcss}
+
 
 # TESTING
 

--- a/core/pdfmaker/pdfmaker.rb
+++ b/core/pdfmaker/pdfmaker.rb
@@ -72,7 +72,7 @@ docpdf = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "layout", "docraptor.h
 File.open(docpdf, "w") {|file| file.puts pdf_html}
 
 doccss = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "layout", "docraptor.css")
-File.open(docpdf, "w") {|file| file.puts embedcss}
+File.open(doccss, "w") {|file| file.puts embedcss}
 
 
 # TESTING

--- a/core/pdfmaker/pdfmaker.rb
+++ b/core/pdfmaker/pdfmaker.rb
@@ -27,7 +27,7 @@ end
 # Link to print css in the html head
 cssfile = File.join(Bkmkr::Project.working_dir, "done", Metadata.pisbn, "layout", "pdf.css")
 if File.file?(cssfile)
-	embedcss = File.read(cssfile)
+	embedcss = File.read(cssfile).gsub(/[\\]/,"\\\\")
 else
 	embedcss = " "
 end

--- a/core/pdfmaker/pdfmaker.rb
+++ b/core/pdfmaker/pdfmaker.rb
@@ -27,14 +27,14 @@ end
 # Link to print css in the html head
 cssfile = File.join(Bkmkr::Project.working_dir, "done", Metadata.pisbn, "layout", "pdf.css")
 if File.file?(cssfile)
-	embedcss = File.read(cssfile)
+	embedcss = File.read(cssfile).to_s
 else
 	embedcss = " "
 end
 
 # Link to custom javascript in the html head
 if File.file?(Metadata.printjs)
-	embedjs = File.read(Metadata.printjs)
+	embedjs = File.read(Metadata.printjs).to_s
 else
 	embedjs = " "
 end

--- a/core/pdfmaker/pdfmaker.rb
+++ b/core/pdfmaker/pdfmaker.rb
@@ -27,7 +27,7 @@ end
 # Link to print css in the html head
 cssfile = File.join(Bkmkr::Project.working_dir, "done", Metadata.pisbn, "layout", "pdf.css")
 if File.file?(cssfile)
-	embedcss = File.read(cssfile).to_s
+	embedcss = File.read(cssfile).gsub(/\\/,"\\\\").to_s
 else
 	embedcss = " "
 end

--- a/core/pdfmaker/pdfmaker.rb
+++ b/core/pdfmaker/pdfmaker.rb
@@ -69,13 +69,13 @@ end
 # moves rendered pdf to archival dir
 FileUtils.mv("#{Metadata.pisbn}.pdf","#{Bkmkr::Paths.done_dir}/#{Metadata.pisbn}/#{Metadata.pisbn}_POD.pdf")
 
-#temporary, for testing
-docpdf = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "layout", "docraptor.html")
-File.open(docpdf, "w") {|file| file.puts pdf_html}
+if File.file?(cssfile)
+	revertcss = File.read(cssfile).gsub(/(\\)(\\)/,"\\1")
+else
+	revertcss = " "
+end
 
-doccss = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "layout", "docraptor.css")
-File.open(doccss, "w") {|file| file.puts embedcss}
-
+File.open(cssfile, "w") {|file| file.puts revertcss}
 
 # TESTING
 

--- a/core/pdfmaker/pdfmaker.rb
+++ b/core/pdfmaker/pdfmaker.rb
@@ -27,7 +27,7 @@ end
 # Link to print css in the html head
 cssfile = File.join(Bkmkr::Project.working_dir, "done", Metadata.pisbn, "layout", "pdf.css")
 if File.file?(cssfile)
-	embedcss = File.read(cssfile).gsub(/\\/,"\\\\").to_s
+	embedcss = File.read(cssfile)
 else
 	embedcss = " "
 end

--- a/core/pdfmaker/pdfmaker.rb
+++ b/core/pdfmaker/pdfmaker.rb
@@ -27,7 +27,7 @@ end
 # Link to print css in the html head
 cssfile = File.join(Bkmkr::Project.working_dir, "done", Metadata.pisbn, "layout", "pdf.css")
 if File.file?(cssfile)
-	embedcss = File.read(cssfile).gsub(/[\\]/,"\\\\")
+	embedcss = File.read(cssfile).gsub(/(\\)/,"\\0\\0")
 else
 	embedcss = " "
 end

--- a/core/pdfmaker/pdfmaker.rb
+++ b/core/pdfmaker/pdfmaker.rb
@@ -32,6 +32,8 @@ else
 	embedcss = " "
 end
 
+File.open(cssfile, "w") {|file| file.puts embedcss}
+
 # Link to custom javascript in the html head
 if File.file?(Metadata.printjs)
 	embedjs = File.read(Metadata.printjs).to_s

--- a/core/pdfmaker/pdfmaker.rb
+++ b/core/pdfmaker/pdfmaker.rb
@@ -67,6 +67,10 @@ end
 # moves rendered pdf to archival dir
 FileUtils.mv("#{Metadata.pisbn}.pdf","#{Bkmkr::Paths.done_dir}/#{Metadata.pisbn}/#{Metadata.pisbn}_POD.pdf")
 
+#temporary, for testing
+docpdf = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "layout", "docraptor.html")
+File.open(docpdf, "w") {|file| file.puts pdf_html}
+
 
 # TESTING
 


### PR DESCRIPTION
Escape chars (\) were getting dropped when the CSS was embedded in the docraptor HTML. Fixed.