### PR TITLE
Updating required folder structure

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -3,6 +3,9 @@
 $currpath = Dir.pwd
 $currvol = $currpath.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).shift
 
+input_file = ARGV[0].split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).join(File::SEPARATOR)
+working_dir = input_file.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact))[0...-2].join(File::SEPARATOR)
+
 # ------------------ GLOBAL VARIABLES
 # These variables are required throughout the 
 # Bookmaker toolchain. Update these paths to 
@@ -39,17 +42,28 @@ $saxon_version = "saxon9pe"
 $pdf_processor = "docraptor"
 #$pdf_processor = "prince"
 
+# ------------------ OPTIONAL VARIABLES
+# uncomment as needed
+
+# Where will you drop assets to accompany your input files? 
+# For example, the config.json, images, cover, etc.
+# If not specified, bookmaker will look in the same folder 
+# as the input file.
+$assets_dir = File.join(working_dir, "submitted_images")
+
+# Where should the output files be stored? 
+# If not specified, bookmaker will make a new subfolder 
+# within the input foler, named by project isbn or filename,
+$done_dir = File.join(working_dir, "done")
+
+# If the standard windows and mac/unix python commands don't work for you,
+# or you want to install python in a location other than $resource_dir,
+# you can specify a custom path/command here.
+# $python_processor = ""
+
 # Your API key to create PDFs via DocRaptor
 $docraptor_key = File.read("#{$scripts_dir}/bookmaker_authkeys/api_key.txt")
 
 # username and password for online resources
 $http_username = File.read("#{$scripts_dir}/bookmaker_authkeys/ftp_username.txt")
 $http_password = File.read("#{$scripts_dir}/bookmaker_authkeys/ftp_pass.txt")
-
-# OPTIONAL VARIABLES
-# uncomment as needed
-
-# If the standard windows and mac/unix python commands don't work for you,
-# or you want to install python in a location other than $resource_dir,
-# you can specify a custom path/command here.
-# $python_processor = ""

--- a/core/coverchecker/coverchecker.rb
+++ b/core/coverchecker/coverchecker.rb
@@ -3,17 +3,21 @@ require 'fileutils'
 require_relative '../header.rb'
 require_relative '../metadata.rb'
 
-# The directory where the cover was moved in tmparchive
-coverdir = Bkmkr::Paths.project_tmp_dir_img
+configfile = File.join(Bkmkr::Paths.project_tmp_dir, "config.json")
+file = File.read(configfile)
+data_hash = JSON.parse(file)
 
-# the revised cover filename
-cover = "#{Metadata.pisbn}_FC.jpg"
+# the cover filename
+cover = data_hash['frontcover']
+
+# The directory where the cover was submitted
+coverdir = Bkmkr::Paths.submitted_images
 
 # the full path to the cover in tmp, including file name
-tmp_cover = File.join(Bkmkr::Paths.project_tmp_dir_img, cover)
+tmp_cover = File.join(Bkmkr::Paths.submitted_images, cover)
 
 # the full path to the cover in the archival location, including file name
-final_cover = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "cover", "cover.jpg")
+final_cover = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "cover", cover)
 
 # full path of cover error file
 cover_error = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "COVER_ERROR.txt")
@@ -30,7 +34,7 @@ end
 # if yes, copies cover to archival location and deletes from submission dir
 # if no, prints an error to the archival directory 
 if files.include?("#{cover}")
-	FileUtils.cp(tmp_cover, final_cover)
+	FileUtils.mv(tmp_cover, final_cover)
 else
 	File.open(cover_error, 'w') do |output|
 		output.write "There is no cover image for this title. Download the cover image from Biblio and place it in the submitted_images folder, then re-submit the manuscript for conversion; cover images must be named ISBN_FC.jpg."

--- a/core/epubmaker/epubmaker.rb
+++ b/core/epubmaker/epubmaker.rb
@@ -3,6 +3,12 @@ require 'FileUtils'
 require_relative '../header.rb'
 require_relative '../metadata.rb'
 
+configfile = File.join(Bkmkr::Paths.project_tmp_dir, "config.json")
+file = File.read(configfile)
+data_hash = JSON.parse(file)
+
+cover = data_hash['frontcover']
+
 # Local path var(s)
 epub_dir = Bkmkr::Paths.project_tmp_dir
 saxonpath = File.join(Bkmkr::Paths.resource_dir, "saxon", "#{Bkmkr::Tools.xslprocessor}.jar")
@@ -12,6 +18,7 @@ epub_xsl = File.join(Bkmkr::Paths.scripts_dir, "HTMLBook", "htmlbook-xsl", "epub
 tmp_epub = File.join(Bkmkr::Paths.project_tmp_dir, "tmp.epub")
 convert_log_txt = File.join(Bkmkr::Paths.log_dir, "#{Bkmkr::Project.filename}.txt")
 OEBPS_dir = File.join(Bkmkr::Paths.project_tmp_dir, "OEBPS")
+final_cover = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "cover", cover)
 cover_jpg = File.join(OEBPS_dir, "cover.jpg")
 epub_img_dir = File.join(Bkmkr::Paths.project_tmp_dir, "epubimg")
 
@@ -55,7 +62,7 @@ File.open("#{OEBPS_dir}/content.opf", "w") {|file| file.puts replace}
 FileUtils.cp("#{Bkmkr::Paths.done_dir}/#{Metadata.pisbn}/layout/epub.css", OEBPS_dir)
 
 # add cover image file to epub folder
-FileUtils.cp("#{Bkmkr::Paths.done_dir}/#{Metadata.pisbn}/cover/cover.jpg", OEBPS_dir)
+FileUtils.cp(final_cover, cover_jpg)
 `convert "#{cover_jpg}" -resize "600x800>" "#{cover_jpg}"`
 
 # add image files to epub folder

--- a/core/filearchive/filearchive.rb
+++ b/core/filearchive/filearchive.rb
@@ -12,7 +12,8 @@ final_dir_cover = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "cover")
 final_dir_layout = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "layout")
 final_manuscript = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "#{Metadata.pisbn}_MNU.#{filetype}")
 final_html = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "layout", "#{Metadata.pisbn}.html")
-input_config = File.join(Bkmkr::Paths.project_tmp_dir, "config.json")
+input_config = File.join(Bkmkr::Paths.submitted_images, "config.json")
+tmp_config = File.join(Bkmkr::Paths.project_tmp_dir, "config.json")
 final_config = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "layout", "config.json")
 
 unless Dir.exist?(final_dir)
@@ -25,6 +26,7 @@ end
 FileUtils.cp(Bkmkr::Project.input_file, final_manuscript)
 FileUtils.cp(Bkmkr::Paths.outputtmp_html, final_html)
 FileUtils.cp(input_config, final_config)
+FileUtils.mv(input_config, tmp_config)
 
 # TESTING
 

--- a/core/filearchive/filearchive.rb
+++ b/core/filearchive/filearchive.rb
@@ -12,7 +12,6 @@ final_dir_cover = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "cover")
 final_dir_layout = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "layout")
 final_manuscript = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "#{Metadata.pisbn}_MNU.#{filetype}")
 final_html = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "layout", "#{Metadata.pisbn}.html")
-input_config = File.join(Bkmkr::Paths.submitted_images, "config.json")
 tmp_config = File.join(Bkmkr::Paths.project_tmp_dir, "config.json")
 final_config = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "layout", "config.json")
 
@@ -25,8 +24,7 @@ end
 
 FileUtils.cp(Bkmkr::Project.input_file, final_manuscript)
 FileUtils.cp(Bkmkr::Paths.outputtmp_html, final_html)
-FileUtils.cp(input_config, final_config)
-FileUtils.mv(input_config, tmp_config)
+FileUtils.cp(tmp_config, final_config)
 
 # TESTING
 

--- a/core/header.rb
+++ b/core/header.rb
@@ -19,21 +19,13 @@ module Bkmkr
 		def self.filename_normalized
 			@@filename_normalized
 		end
-		@@working_dir_split = input_file.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact))
-		def self.working_dir_split
-			@@working_dir_split
+		@@input_dir = input_file.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact))[0...-1].join(File::SEPARATOR)
+		def self.input_dir
+			@@input_dir
 		end
 		@@working_dir = input_file.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact))[0...-2].join(File::SEPARATOR)
 		def self.working_dir
 			@@working_dir
-		end
-		@@project_dir = input_file.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact))[0...-2].pop.to_s.split("_").shift
-		def self.project_dir
-			@@project_dir
-		end
-		@@stage_dir = input_file.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact))[0...-2].pop.to_s.split("_").pop
-		def self.stage_dir
-			@@stage_dir
 		end
 	end
 
@@ -60,10 +52,13 @@ module Bkmkr
 			@@core_dir
 		end
 
-		# Path to the submitted_images directory
-		@@submitted_images = File.join(Project.working_dir, "submitted_images")
+		# Path to the submitted_assets directory
 		def self.submitted_images
-			@@submitted_images
+			if $assets_dir
+				$assets_dir
+			else 
+				Project.input_dir
+			end
 		end
 
 		# Path to the temporary working directory
@@ -97,9 +92,12 @@ module Bkmkr
 		end
 
 		# Full path and filename for the "done" directory in Project working directory
-		@@done_dir = File.join(Project.working_dir, "done")
 		def self.done_dir
-			@@done_dir
+			if $done_dir
+				$done_dir
+			else 
+				Project.input_dir
+			end
 		end
 
 		# Full path to project log file
@@ -111,15 +109,27 @@ module Bkmkr
 
 	class Keys
 		def self.docraptor_key
-	      $docraptor_key
+	      if $docraptor_key
+	      	$docraptor_key
+	      else
+	      	"none"
+	      end
 	    end
 
 	    def self.http_username
-	      $http_username
+	      if $http_username
+	      	$http_username
+	      else
+	      	"none"
+	      end
 	    end
 
 	    def self.http_password
-	      $http_password
+	      if $http_password
+	      	$http_password
+	      else
+	      	"none"
+	      end
 	    end
 	end
 

--- a/core/imagechecker/imagechecker.rb
+++ b/core/imagechecker/imagechecker.rb
@@ -4,7 +4,7 @@ require_relative '../header.rb'
 require_relative '../metadata.rb'
 
 # The location where the images are moved to by tmparchive
-imagedir = Bkmkr::Paths.project_tmp_dir_img
+imagedir = Bkmkr::Paths.submitted_images
 
 # The working dir location that images will be moved to (for test 3)
 image_dest = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
@@ -45,6 +45,7 @@ source.each do |m|
 	if images.include?("#{match}")
 		FileUtils.cp(matched_file, image_dest)
 		matched << match
+		FileUtils.mv(matched_file, Bkmkr::Paths.project_tmp_dir_img)
 	else
 		missing << match
 	end

--- a/core/metadata.rb
+++ b/core/metadata.rb
@@ -13,7 +13,7 @@ class Metadata
 		if @@data_hash['title']
 			@@data_hash['title']
 		else 
-			"Unknown"
+			Bkmkr::Project.filename
 		end
 	end
 
@@ -37,7 +37,7 @@ class Metadata
 		if @@data_hash['productid']
 			@@data_hash['productid']
 		else 
-			"Unknown"
+			Bkmkr::Project.filename
 		end
 	end
 
@@ -45,7 +45,7 @@ class Metadata
 		if @@data_hash['printid']
 			@@data_hash['printid']
 		else 
-			"Unknown"
+			Bkmkr::Project.filename
 		end
 	end
 
@@ -53,7 +53,7 @@ class Metadata
 		if @@data_hash['ebookid']
 			@@data_hash['ebookid']
 		else 
-			"Unknown"
+			Bkmkr::Project.filename
 		end
 	end
 

--- a/core/tmparchive/tmparchive.rb
+++ b/core/tmparchive/tmparchive.rb
@@ -7,6 +7,8 @@ test_images_before = Dir.entries(Bkmkr::Paths.submitted_images)
 
 # Local path variables
 all_submitted_images = Dir.entries(Bkmkr::Paths.submitted_images)
+input_config = File.join(Bkmkr::Paths.submitted_images, "config.json")
+tmp_config = File.join(Bkmkr::Paths.project_tmp_dir, "config.json")
 
 # Rename and move input files to tmp folder to eliminate possibility of overwriting
 if Dir.exist?(Bkmkr::Paths.project_tmp_dir)
@@ -15,6 +17,9 @@ end
 Dir.mkdir(Bkmkr::Paths.project_tmp_dir)
 Dir.mkdir(Bkmkr::Paths.project_tmp_dir_img)
 FileUtils.cp(Bkmkr::Project.input_file, Bkmkr::Paths.project_tmp_file)
+if File.file?(input_config)
+	FileUtils.mv(input_config, tmp_config)
+end
 
 # Add a notice to the conversion dir warning that the process is in use
 File.open("#{Bkmkr::Paths.alert}", 'w') do |output|

--- a/core/tmparchive/tmparchive.rb
+++ b/core/tmparchive/tmparchive.rb
@@ -16,13 +16,6 @@ Dir.mkdir(Bkmkr::Paths.project_tmp_dir)
 Dir.mkdir(Bkmkr::Paths.project_tmp_dir_img)
 FileUtils.cp(Bkmkr::Project.input_file, Bkmkr::Paths.project_tmp_file)
 
-all_submitted_images.each do |c|
-	unless c.include?(".db") or c.include?("DS_Store") or c == "." or c ==".."
-		filename = c.split("/").pop
-		FileUtils.mv("#{Bkmkr::Paths.submitted_images}/#{c}", "#{Bkmkr::Paths.project_tmp_dir_img}/#{filename}")
-	end
-end
-
 # Add a notice to the conversion dir warning that the process is in use
 File.open("#{Bkmkr::Paths.alert}", 'w') do |output|
 	output.write "The conversion processor is currently running. Please do not submit any new files or images until the process completes."


### PR DESCRIPTION
Users can now either define a directory for submitting project assets as well as a directory for storing finished conversions, or bookmaker will just look in the same folder where the input file was submitted, and store the finished stuff there.