### PR TITLE
Adding support for titlepage images

### DIFF
--- a/core/metadata.rb
+++ b/core/metadata.rb
@@ -104,4 +104,20 @@ class Metadata
 			@@data_hash['frontcover']
 		end
 	end
+
+	def self.epubtitlepage
+		if @@data_hash['epubtitlepage'].empty? or !@@data_hash['epubtitlepage']
+			"Unknown"
+		else 
+			@@data_hash['epubtitlepage']
+		end
+	end
+
+	def self.podtitlepage
+		if @@data_hash['podtitlepage'].empty? or !@@data_hash['podtitlepage']
+			"Unknown"
+		else 
+			@@data_hash['podtitlepage']
+		end
+	end
 end

--- a/core/pdfmaker/pdfmaker.rb
+++ b/core/pdfmaker/pdfmaker.rb
@@ -64,7 +64,7 @@ else
 end
 
 File.open(cssfile, "w") {|file| file.puts revertcss}
-FileUtils.rm(pdf_tmp_html)
+#FileUtils.rm(pdf_tmp_html)
 
 # LOGGING
 


### PR DESCRIPTION
Users can include separate title page images for POD and EPUB, specifying filenames in the project JSON.