### PR TITLE
Fallback to use previous images if no new images submitted

### DIFF
--- a/core/coverchecker/coverchecker.rb
+++ b/core/coverchecker/coverchecker.rb
@@ -35,10 +35,14 @@ end
 # if no, prints an error to the archival directory 
 if files.include?("#{cover}")
 	FileUtils.mv(tmp_cover, final_cover)
+	covercheck = "Found a new cover submitted"
+elsif !files.include?("#{cover}") and File.file?(final_cover)
+	covercheck = "Picking up existing cover"
 else
 	File.open(cover_error, 'w') do |output|
 		output.write "There is no cover image for this title. Download the cover image from Biblio and place it in the submitted_images folder, then re-submit the manuscript for conversion; cover images must be named ISBN_FC.jpg."
 	end
+	covercheck = "No cover found"
 end
 
 # LOGGING
@@ -46,5 +50,6 @@ end
 # Printing the test results to the log file
 File.open(Bkmkr::Paths.log_file, 'a+') do |f|
 	f.puts "----- COVERCHECKER PROCESSES"
+	f.puts covercheck
 	f.puts "finished coverchecker"
 end

--- a/core/imagechecker/imagechecker.rb
+++ b/core/imagechecker/imagechecker.rb
@@ -3,8 +3,10 @@ require 'fileutils'
 require_relative '../header.rb'
 require_relative '../metadata.rb'
 
-# The location where the images are moved to by tmparchive
+# The locations to check for images
 imagedir = Bkmkr::Paths.submitted_images
+final_dir_images = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
+final_cover = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "cover", Metadata.frontcover)
 
 # The working dir location that images will be moved to (for test 3)
 image_dest = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
@@ -14,6 +16,9 @@ image_error = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "IMAGE_ERROR.txt"
 
 # An array listing all the submitted images
 images = Dir.entries("#{imagedir}")
+
+# An array listing all images in the archive dir
+finalimages = Dir.entries("#{final_dir_images}")
 
 # If a cover_error file exists, delete it
 if File.file?(image_error)
@@ -42,14 +47,17 @@ matched = []
 source.each do |m|
 	match = m.split("/").pop.gsub(/"/,'')
 	matched_file = File.join(imagedir, match)
+	matched_file_pickup = File.join(final_dir_images, match)
 	if images.include?("#{match}") and match == Metadata.frontcover
-		FileUtils.cp(matched_file, image_dest)
 		matched << match
 		FileUtils.cp(matched_file, Bkmkr::Paths.project_tmp_dir_img)
 	elsif images.include?("#{match}") and match != Metadata.frontcover
 		FileUtils.cp(matched_file, image_dest)
 		matched << match
 		FileUtils.mv(matched_file, Bkmkr::Paths.project_tmp_dir_img)
+	elsif !images.include?("#{match}") and match != Metadata.frontcover and finalimages.include?("#{match}")
+		matched << match
+		FileUtils.cp(matched_file_pickup, Bkmkr::Paths.project_tmp_dir_img)
 	else
 		missing << match
 	end


### PR DESCRIPTION
If images are not submitted, bookmaker will check for previous existing versions of images and covers and pick those up for current conversions