### PR TITLE
Adding support for CSS imports

### DIFF
--- a/core/stylesheets/stylesheets.rb
+++ b/core/stylesheets/stylesheets.rb
@@ -11,12 +11,12 @@ def evalImports(file, path)
 		imports.each do |i|
 			importarr = i.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact))
 			importfile = i.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
-			if importarr.length? >= 2 and importarr.include? ".."
+			if importarr.count? >= 2 and importarr.include? ".."
 				searchdir = thispath.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact))[0...-2].join(File::SEPARATOR)
 				importpath = File.join(searchdir, importfile)
-			elsif importarr.length? >= 2 and importarr.include? "."
+			elsif importarr.count? >= 2 and importarr.include? "."
 				importpath = File.join(thispath, importfile)
-			elsif importarr.length? >= 2
+			elsif importarr.count? >= 2
 				searchdir = i.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).join(File::SEPARATOR)
 				importpath = File.join(searchdir, importfile)
 			else

--- a/core/stylesheets/stylesheets.rb
+++ b/core/stylesheets/stylesheets.rb
@@ -7,6 +7,7 @@ def evalImports(file, path)
 	filecontents = File.read(file)
 	thispath = file.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact))[0...-1].join(File::SEPARATOR)
 	if filecontents.include? "@import"
+		puts "found a CSS import file"
 		imports = filecontents.scan(/@import.*?;{1}/)
 		imports.each do |i|
 			importarr = i.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact))
@@ -66,6 +67,14 @@ chapterheads = File.read(Bkmkr::Paths.outputtmp_html).scan(/section data-type="c
 tmp_layout_dir = File.join(Bkmkr::Project.working_dir, "done", Metadata.pisbn, "layout")
 tmp_pdf_css = File.join(tmp_layout_dir, "pdf.css")
 tmp_epub_css = File.join(tmp_layout_dir, "epub.css")
+
+if File.file?(tmp_pdf_css)
+	FileUtils.rm(tmp_pdf_css)
+end
+
+if File.file?(tmp_epub_css)
+	FileUtils.rm(tmp_epub_css)
+end
 
 pdf_css_file = Metadata.printcss
 epub_css_file = Metadata.epubcss

--- a/core/stylesheets/stylesheets.rb
+++ b/core/stylesheets/stylesheets.rb
@@ -3,11 +3,68 @@ require 'fileutils'
 require_relative '../header.rb'
 require_relative '../metadata.rb'
 
+def evalImports(file, path)
+	filecontents = File.read(file)
+	thispath = file.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact))[0...-1].join(File::SEPARATOR)
+	if filecontents.include? "@import"
+		imports = filecontents.scan(/@import.*?;{1}/)
+		imports.each do |i|
+			importarr = i.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact))
+			importfile = i.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
+			if importarr.length? >= 2 and importarr.include? ".."
+				searchdir = thispath.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact))[0...-2].join(File::SEPARATOR)
+				importpath = File.join(searchdir, importfile)
+			elsif importarr.length? >= 2 and importarr.include? "."
+				importpath = File.join(thispath, importfile)
+			elsif importarr.length? >= 2
+				searchdir = i.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).join(File::SEPARATOR)
+				importpath = File.join(searchdir, importfile)
+			else
+				importpath = File.join(thispath, importfile)
+			end
+			if File.file?(importpath)
+				thisimport = File.read(importpath)
+				File.open(path, 'a+') do |p|
+					p.write thisimport
+				end
+			end
+		end
+	end
+end
+
+def copyCSS(file, path)
+	filecontents = File.read(file)
+	filecontents = filecontents.gsub(/@import.*?;{1}/, "")
+	File.open(path, 'a+') do |p|
+		p.write filecontents
+	end
+end
+
+def evalOneoffs(file, path)
+	oneoffcss_new = File.join(Bkmkr::Paths.submitted_images, file)
+	oneoffcss_pickup = File.join(tmp_layout_dir, file)
+
+	if File.file?(oneoffcss_new)
+		FileUtils.mv(oneoffcss_new, oneoffcss_pickup)
+		oneoffcss = File.read(oneoffcss_pickup)
+		File.open(path, 'a+') do |o|
+			o.write oneoffcss
+		end
+	elsif File.file?(oneoffcss_pickup)
+		oneoffcss = File.read(oneoffcss_pickup)
+		File.open(path, 'a+') do |o|
+			o.write oneoffcss
+		end
+	end
+end
+
 # an array of all occurances of chapters in the manuscript
 chapterheads = File.read(Bkmkr::Paths.outputtmp_html).scan(/section data-type="chapter"/)
 
 # Local path vars, css files 
 tmp_layout_dir = File.join(Bkmkr::Project.working_dir, "done", Metadata.pisbn, "layout")
+tmp_pdf_css = File.join(tmp_layout_dir, "pdf.css")
+tmp_epub_css = File.join(tmp_layout_dir, "epub.css")
 
 pdf_css_file = Metadata.printcss
 epub_css_file = Metadata.epubcss
@@ -16,58 +73,34 @@ find_pdf_css_file = File.join(Bkmkr::Paths.submitted_images, Metadata.printcss)
 find_epub_css_file = File.join(Bkmkr::Paths.submitted_images, Metadata.epubcss)
 
 if File.file?(pdf_css_file)
-	FileUtils.cp(pdf_css_file, "#{tmp_layout_dir}/pdf.css")
+	evalImports(pdf_css_file, tmp_pdf_css)
+	copyCSS(pdf_css_file, tmp_pdf_css)
 elsif File.file?(find_pdf_css_file)
-	FileUtils.cp(find_pdf_css_file, "#{tmp_layout_dir}/pdf.css")
+	evalImports(find_pdf_css_file, tmp_pdf_css)
+	copyCSS(find_pdf_css_file, tmp_pdf_css)
 	FileUtils.rm(find_pdf_css_file)
 else
-	File.open("#{tmp_layout_dir}/pdf.css", 'w') do |p|
+	File.open("#{tmp_layout_dir}/pdf.css", 'a+') do |p|
 		p.write "/* no print css supplied */"
 	end
 end
 
-oneoffcss_p_new = File.join(Bkmkr::Paths.submitted_images, "oneoff_pdf.css")
-oneoffcss_p_pickup = File.join(tmp_layout_dir, "oneoff_pdf.css")
-
-if File.file?(oneoffcss_p_new)
-	FileUtils.mv(oneoffcss_p_new, oneoffcss_p_pickup)
-	oneoffcss = File.read(oneoffcss_p_pickup)
-	File.open("#{tmp_layout_dir}/pdf.css", 'a+') do |o|
-		o.write oneoffcss
-	end
-elsif File.file?(oneoffcss_p_pickup)
-	oneoffcss = File.read(oneoffcss_p_pickup)
-	File.open("#{tmp_layout_dir}/pdf.css", 'a+') do |o|
-		o.write oneoffcss
-	end
-end
+evalOneoffs("oneoff_pdf.css", tmp_pdf_css)
 
 if File.file?(epub_css_file)
-	FileUtils.cp(epub_css_file, "#{tmp_layout_dir}/epub.css")
+	evalImports(epub_css_file, tmp_epub_css)
+	copyCSS(epub_css_file, tmp_epub_css)
 elsif File.file?(find_epub_css_file)
-	FileUtils.cp(find_epub_css_file, "#{tmp_layout_dir}/epub.css")
+	evalImports(find_epub_css_file, tmp_epub_css)
+	copyCSS(find_epub_css_file, tmp_epub_css)
 	FileUtils.rm(find_epub_css_file)
 else
-	File.open("#{tmp_layout_dir}/epub.css", 'w') do |e|
+	File.open("#{tmp_layout_dir}/epub.css", 'a+') do |e|
 		e.write "/* no epub css supplied */"
 	end
 end
 
-oneoffcss_e_new = File.join(Bkmkr::Paths.submitted_images, "oneoff_epub.css")
-oneoffcss_e_pickup = File.join(tmp_layout_dir, "oneoff_epub.css")
-
-if File.file?(oneoffcss_e_new)
-	FileUtils.mv(oneoffcss_e_new, oneoffcss_e_pickup)
-	oneoffcss = File.read(oneoffcss_e_pickup)
-	File.open("#{tmp_layout_dir}/epub.css", 'a+') do |o|
-		o.write oneoffcss
-	end
-elsif File.file?(oneoffcss_e_pickup)
-	oneoffcss = File.read(oneoffcss_e_pickup)
-	File.open("#{tmp_layout_dir}/epub.css", 'a+') do |o|
-		o.write oneoffcss
-	end
-end
+evalOneoffs("oneoff_epub.css", tmp_epub_css)
 
 # LOGGING
 

--- a/core/stylesheets/stylesheets.rb
+++ b/core/stylesheets/stylesheets.rb
@@ -10,6 +10,8 @@ def evalImports(file, path)
 		puts "found a CSS import file"
 		imports = filecontents.scan(/@import.*?;{1}/)
 		imports.each do |i|
+			myimport = i.gsub(/@import/,"").gsub(/\"/,"").gsub(/\'/,"")
+			myimport = myimport.gsub(/^\s*/,"")
 			importarr = i.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact))
 			importfile = i.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
 			if importarr.length >= 2 and importarr.include? ".."

--- a/core/stylesheets/stylesheets.rb
+++ b/core/stylesheets/stylesheets.rb
@@ -10,7 +10,7 @@ def evalImports(file, path)
 		puts "found a CSS import file"
 		imports = filecontents.scan(/@import.*?;{1}/)
 		imports.each do |i|
-			myimport = i.gsub(/@import/,"").gsub(/\"/,"").gsub(/\'/,"")
+			myimport = i.gsub(/@import/,"").gsub(/\"/,"").gsub(/\'/,"").gsub(/;/,"")
 			myimport = myimport.gsub(/^\s*/,"")
 			importarr = myimport.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact))
 			importfile = myimport.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop

--- a/core/stylesheets/stylesheets.rb
+++ b/core/stylesheets/stylesheets.rb
@@ -11,12 +11,12 @@ def evalImports(file, path)
 		imports.each do |i|
 			importarr = i.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact))
 			importfile = i.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
-			if importarr.count? >= 2 and importarr.include? ".."
+			if importarr.length >= 2 and importarr.include? ".."
 				searchdir = thispath.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact))[0...-2].join(File::SEPARATOR)
 				importpath = File.join(searchdir, importfile)
-			elsif importarr.count? >= 2 and importarr.include? "."
+			elsif importarr.length >= 2 and importarr.include? "."
 				importpath = File.join(thispath, importfile)
-			elsif importarr.count? >= 2
+			elsif importarr.length >= 2
 				searchdir = i.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).join(File::SEPARATOR)
 				importpath = File.join(searchdir, importfile)
 			else

--- a/core/stylesheets/stylesheets.rb
+++ b/core/stylesheets/stylesheets.rb
@@ -41,6 +41,7 @@ def copyCSS(file, path)
 end
 
 def evalOneoffs(file, path)
+	tmp_layout_dir = File.join(Bkmkr::Project.working_dir, "done", Metadata.pisbn, "layout")
 	oneoffcss_new = File.join(Bkmkr::Paths.submitted_images, file)
 	oneoffcss_pickup = File.join(tmp_layout_dir, file)
 

--- a/core/stylesheets/stylesheets.rb
+++ b/core/stylesheets/stylesheets.rb
@@ -23,6 +23,7 @@ def evalImports(file, path)
 			else
 				importpath = File.join(thispath, importfile)
 			end
+			puts "CSS import file: #{importpath}"
 			if File.file?(importpath)
 				thisimport = File.read(importpath)
 				File.open(path, 'a+') do |p|

--- a/core/stylesheets/stylesheets.rb
+++ b/core/stylesheets/stylesheets.rb
@@ -12,15 +12,15 @@ def evalImports(file, path)
 		imports.each do |i|
 			myimport = i.gsub(/@import/,"").gsub(/\"/,"").gsub(/\'/,"")
 			myimport = myimport.gsub(/^\s*/,"")
-			importarr = i.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact))
-			importfile = i.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
+			importarr = myimport.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact))
+			importfile = myimport.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
 			if importarr.length >= 2 and importarr.include? ".."
 				searchdir = thispath.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact))[0...-2].join(File::SEPARATOR)
 				importpath = File.join(searchdir, importfile)
 			elsif importarr.length >= 2 and importarr.include? "."
 				importpath = File.join(thispath, importfile)
 			elsif importarr.length >= 2
-				searchdir = i.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).join(File::SEPARATOR)
+				searchdir = myimport.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).join(File::SEPARATOR)
 				importpath = File.join(searchdir, importfile)
 			else
 				importpath = File.join(thispath, importfile)


### PR DESCRIPTION
CSS imports are now supported. If a printcss or epubcss references an import, bookmaker will source that in first, and then add the standard CSS and finally any oneoff CSS. Only supports locally-hosted CSS (e.g., can't resolve weblinks currently).