### PR TITLE
Adding processing instruction support

### DIFF
--- a/core/htmlmaker/evaluate_pis.js
+++ b/core/htmlmaker/evaluate_pis.js
@@ -8,7 +8,7 @@ fs.readFile(file, function processTemplates (err, contents) {
         });
 
   // evaluate processing instructions
-  $("p.bookmakerprocessinginstructionbpi").each(function () {
+  $("p.BookmakerProcessingInstructionbpi").each(function () {
       var val = $( this ).text()
       if (val = "Ebook-only") {
         $( this ).parent().attr('data-format','ebook')

--- a/core/htmlmaker/evaluate_pis.js
+++ b/core/htmlmaker/evaluate_pis.js
@@ -1,0 +1,29 @@
+var fs = require('fs');
+var cheerio = require('cheerio');
+var file = process.argv[2];
+
+fs.readFile(file, function processTemplates (err, contents) {
+  $ = cheerio.load(contents, {
+          xmlMode: true
+        });
+
+  // evaluate processing instructions
+  $("p.bookmakerprocessinginstructionbpi").each(function () {
+      var val = $( this ).text()
+      if (val = "Ebook-only") {
+        $( this ).parent().attr('data-format','ebook')
+      } else if ($( this ).text() = "Print-only") {
+        $( this ).parent().attr('data-format','print')
+      }
+      $(this).remove();
+  });
+
+  var output = $.html();
+    fs.writeFile(file, output, function(err) {
+	    if(err) {
+	        return console.log(err);
+	    }
+
+	    console.log("Processing instructions have been evaluated!");
+	});
+});

--- a/core/htmlmaker/htmlmaker.rb
+++ b/core/htmlmaker/htmlmaker.rb
@@ -22,6 +22,8 @@ headings_xsl = File.join(Bkmkr::Paths.core_dir, "htmlmaker", "headings.xsl")
 
 inlines_xsl = File.join(Bkmkr::Paths.core_dir, "htmlmaker", "inlines.xsl")
 
+evaluate_pis = File.join(Bkmkr::Paths.core_dir, "htmlmaker", "evaluate_pis.js")
+
 # ---------------------- METHODS
 
 def fixFootnotes(content)
@@ -105,6 +107,9 @@ filecontents = File.read(Bkmkr::Paths.outputtmp_html)
 filecontents = stripEndnotes(filecontents)
 
 Mcmlln::Tools.overwriteFile(Bkmkr::Paths.outputtmp_html, filecontents)
+
+# evaluate processing instructions
+Bkmkr::Tools.runnode(evaluate_pis, Bkmkr::Paths.outputtmp_html)
 
 # ---------------------- LOGGING
 


### PR DESCRIPTION
Adding support for in-text processing instructions. Paragraphs tagged as "Bookmaker Processing Instruction (bpi)" will have the text processed as defined in https://github.com/macmillanpublishers/bookmaker/tree/master/core/htmlmaker/evaluate_pis.js and then those paragraphs will be removed.