### PR TITLE
Revising handling for addon images

### DIFF
--- a/core/epubmaker/epubmaker.rb
+++ b/core/epubmaker/epubmaker.rb
@@ -134,6 +134,20 @@ def convertInteriorImg(file, dir)
 	end
 end
 
+def copyInteriorImg(dir, opf, dest)
+	images = Mcmlln::Tools.dirListFiles(dir)
+	opfcontents = File.read(opf)
+	copied = []
+	images.each do |i|
+		path_to_i = File.join(dir, i)
+		if opfcontents.include? i
+			Mcmlln::Tools.copyFile(path_to_i, dest)
+			copied << i
+		end
+	end
+	copied
+end
+
 # ---------------------- PROCESSES
 deleteOld(OEBPS_dir)
 deleteOld(METAINF_dir)
@@ -202,6 +216,7 @@ if sourceimages.any?
 		end
 	end
 	Mcmlln::Tools.copyAllFiles(epub_img_dir, OEBPS_dir)
+	epubimages = copyInteriorImg(epub_img_dir, content_opf, OEBPS_dir)
 end
 
 # zip epub

--- a/core/epubmaker/epubmaker.rb
+++ b/core/epubmaker/epubmaker.rb
@@ -215,8 +215,8 @@ if sourceimages.any?
 			convertInteriorImg(i, epub_img_dir)
 		end
 	end
-	Mcmlln::Tools.copyAllFiles(epub_img_dir, OEBPS_dir)
 	epubimages = copyInteriorImg(epub_img_dir, content_opf, OEBPS_dir)
+	puts epubimages
 end
 
 # zip epub

--- a/core/header.rb
+++ b/core/header.rb
@@ -352,7 +352,7 @@ module Bkmkr
 								puts i
 								source = i.match(/(src=")(.*?)(")/)[2]
 								imagepath = File.join(addonfiledir, "images", source)
-								fileutils.cp(imagepath, epub_img_dir)
+								Mcmlln::Tools.copyFile(imagepath, epub_img_dir)
 							end
 						end
 

--- a/core/header.rb
+++ b/core/header.rb
@@ -349,7 +349,7 @@ module Bkmkr
 						images = File.read(addonfile).scan(/<img.*?>/)
 						if images.any?
 							images.each do |i|
-								puts i
+								puts "copying addon image file: #{i}"
 								source = i.match(/(src=")(.*?)(")/)[2]
 								imagepath = File.join(addonfiledir, "images", source)
 								Mcmlln::Tools.copyFile(imagepath, epub_img_dir)

--- a/core/header.rb
+++ b/core/header.rb
@@ -346,9 +346,10 @@ module Bkmkr
 						# copy any images to epub conversion dir
 						epub_img_dir = File.join(Bkmkr::Paths.project_tmp_dir, "epubimg")
 						images = []
-						images = addoncontent.scan(/<img/)
+						images = File.read(addonfile).scan(/<img/)
 						if images.any?
 							images.each do |i|
+								puts i
 								source = i.match(/(src=")(.*?)(")/)[2]
 								imagepath = File.join(addonfiledir, "images", source)
 								fileutils.cp(imagepath, epub_img_dir)

--- a/core/header.rb
+++ b/core/header.rb
@@ -345,6 +345,7 @@ module Bkmkr
 
 						# copy any images to epub conversion dir
 						epub_img_dir = File.join(Bkmkr::Paths.project_tmp_dir, "epubimg")
+						images = []
 						images = addoncontent.scan(/<img/)
 						if images.any?
 							images.each do |i|

--- a/core/header.rb
+++ b/core/header.rb
@@ -335,13 +335,6 @@ module Bkmkr
 						addonfile = File.join(addonfiledir, f['filename'])
 						addoncontent = File.read(addonfile).gsub(/\n/,"").gsub(/"/,"\\\"")
 
-						# puts "2= #{inputfile}"
-						# puts "3= #{addoncontent}"
-						# puts "4= #{locationcontainer}"
-						# puts "5= #{locationtype}"
-						# puts "6= #{locationclass}"
-						# puts "7= #{sequence}"
-						# puts "8= #{location}"
 						puts "inserting file: #{addonfile}"
 						puts "insertion location is: #{order} #{location}"
 
@@ -349,6 +342,17 @@ module Bkmkr
 
 						# Insert the addon via node.js
 						Bkmkr::Tools.runnode(jsfile, "\"#{inputfile}\" \"#{addoncontent}\" \"#{locationcontainer}\" \"#{locationtype}\" \"#{locationclass}\" \"#{sequence}\" \"#{order}\" \"#{location}\"")
+
+						# copy any images to epub conversion dir
+						epub_img_dir = File.join(Bkmkr::Paths.project_tmp_dir, "epubimg")
+						images = addoncontent.scan(/<img/)
+						if images.any?
+							images.each do |i|
+								source = i.match(/(src=")(.*?)(")/)[2]
+								imagepath = File.join(addonfiledir, "images", source)
+								fileutils.cp(imagepath, epub_img_dir)
+							end
+						end
 
 						puts "inserted #{addonfile}"
 					end

--- a/core/header.rb
+++ b/core/header.rb
@@ -346,7 +346,7 @@ module Bkmkr
 						# copy any images to epub conversion dir
 						epub_img_dir = File.join(Bkmkr::Paths.project_tmp_dir, "epubimg")
 						images = []
-						images = File.read(addonfile).scan(/<img/)
+						images = File.read(addonfile).scan(/<img.*?>/)
 						if images.any?
 							images.each do |i|
 								puts i


### PR DESCRIPTION
Revising so that an image is only copied into an epub file if it is actually referenced in the file or used in an addon