### PR TITLE
Doubledoc

### DIFF
--- a/core/htmlmaker/docxtoxml.py
+++ b/core/htmlmaker/docxtoxml.py
@@ -11,7 +11,7 @@ def isdir(z, name):
 def convert_manuscript(self):
 
     # must be .docx or .docm
-    path_to_xml_file = self[::-1].replace("xcod", "lmx", 1).replace('mcod', 'xml')[::-1]
+    path_to_xml_file = self[::-1].replace("xcod", "lmx", 1).replace('mcod', 'xml', 1)[::-1]
     extension = os.path.splitext(self)[1]
 
     if extension in ('.docx', '.docm', '.doc'):
@@ -32,11 +32,11 @@ def convert_manuscript(self):
         str3 = "<pkg:part pkg:name=\"/word/footnotes.xml\" pkg:contentType=\"application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml\"><pkg:xmlData>"
         str4 = "</pkg:package>"
         document.close()
-        
+
         file = open(path_to_xml_file, "w")
         file.write(xml_content + str1 + str2 + endnote_content + str1 + str3 + footnote_content + str1 + str4)
         file.close()
 
-        return 
+        return
 
 convert_manuscript( filename )

--- a/core/htmlmaker/docxtoxml.py
+++ b/core/htmlmaker/docxtoxml.py
@@ -11,7 +11,7 @@ def isdir(z, name):
 def convert_manuscript(self):
 
     # must be .docx or .docm
-    path_to_xml_file = self.replace("docx", "xml").replace('docm', 'xml')
+    path_to_xml_file = self[::-1].replace("xcod", "lmx", 1).replace('mcod', 'xml')[::-1]
     extension = os.path.splitext(self)[1]
 
     if extension in ('.docx', '.docm', '.doc'):

--- a/core/htmlmaker/docxtoxml.py
+++ b/core/htmlmaker/docxtoxml.py
@@ -11,7 +11,7 @@ def isdir(z, name):
 def convert_manuscript(self):
 
     # must be .docx or .docm
-    path_to_xml_file = self[::-1].replace("xcod", "lmx", 1).replace('mcod', 'xml', 1)[::-1]
+    path_to_xml_file = self[::-1].replace("xcod", "lmx", 1).replace('mcod', 'lmx', 1)[::-1]
     extension = os.path.splitext(self)[1]
 
     if extension in ('.docx', '.docm', '.doc'):


### PR DESCRIPTION
In the rare case a file has a filename with an extra '.docx' in it, eg: "mygreatMS.docx.docx" this has docxtoxml.py change only the last occurrence of '.docx' to '.xml' (by reversing the string and replacing first occurrence, backwards).  Prevents a crash from htmlmaker.rb.