### PR TITLE
editing runpython method in bkmkr::tools to take many argments

### DIFF
--- a/core/header.rb
+++ b/core/header.rb
@@ -182,14 +182,14 @@ module Bkmkr
 			return stdout_stderr
 		end
 
-		def self.runpython(py_script, input_file)
+		def self.runpython(py_script, args)
 			if $python_processor
-				`#{$python_processor} #{py_script} #{input_file}`
+				`#{$python_processor} #{py_script} #{args}`
 			elsif os == "mac" or os == "unix"
-				`python #{py_script} #{input_file}`
+				`python #{py_script} #{args}`
 			elsif os == "windows"
 				pythonpath = File.join(Paths.resource_dir, "Python27", "python.exe")
-				`#{pythonpath} #{py_script} #{input_file}`
+				`#{pythonpath} #{py_script} #{args}`
 			else
 				File.open(Bkmkr::Paths.log_file, 'a+') do |f|
 					f.puts "----- PYTHON ERROR"


### PR DESCRIPTION
Really a cosmetic change to go with the python dropbox-api, so the run_python method is pointedly accepting multiple arguments.  Tested as part of Bookmaker_addons PR 106, passed tests.