### PR TITLE
Removing inline design notes

### DIFF
--- a/core/htmlmaker/inlines.js
+++ b/core/htmlmaker/inlines.js
@@ -56,6 +56,9 @@ fs.readFile(file, function processTemplates (err, contents) {
     $(this).append(el);
   });
 
+  // remove inline design notes
+  $('span.spandesignnotedni').remove();
+
   var output = $.html();
     fs.writeFile(file, output, function(err) {
 	    if(err) {


### PR DESCRIPTION
Per our standard handling for design notes, we will remove all inline design notes when converting to HTML.

Tested on staging.

@mattretzer or @ericawarren can you review and approve?