### PR TITLE
Remove old logging from bookmaker repo

### DIFF
--- a/core/cleanup/cleanup.rb
+++ b/core/cleanup/cleanup.rb
@@ -49,12 +49,6 @@ deleteFileifExists(Bkmkr::Project.input_file, 'delete_input_file')
 deleteFileifExists(Bkmkr::Paths.alert, 'delete_alert_file')
 
 # ---------------------- LOGGING
-# Printing the test results to the log file
-File.open(Bkmkr::Paths.log_file, 'a+') do |f|
-  f.puts "----- CLEANUP PROCESSES"
-  f.puts "finished cleanup"
-end
-
 # Write json log:
 Mcmlln::Tools.logtoJson(@log_hash, 'completed', Time.now)
 Mcmlln::Tools.write_json(local_log_hash, Bkmkr::Paths.json_log)

--- a/core/coverchecker/coverchecker.rb
+++ b/core/coverchecker/coverchecker.rb
@@ -76,13 +76,6 @@ covercheck = checkCoverFile(files, cover, tmp_cover, final_cover, cover_error, '
 
 
 # ---------------------- LOGGING
-# Printing the test results to the log file
-File.open(Bkmkr::Paths.log_file, 'a+') do |f|
-	f.puts "----- COVERCHECKER PROCESSES"
-	f.puts covercheck
-	f.puts "finished coverchecker"
-end
-
 # Write json log:
 Mcmlln::Tools.logtoJson(@log_hash, 'completed', Time.now)
 Mcmlln::Tools.write_json(local_log_hash, Bkmkr::Paths.json_log)

--- a/core/epubmaker/epubmaker.rb
+++ b/core/epubmaker/epubmaker.rb
@@ -409,15 +409,7 @@ else
 	test_epub_status = "FAIL: the EPUB was created successfully"
 end
 
-# Add new section to log file
-File.open(Bkmkr::Paths.log_file, 'a+') do |f|
-	f.puts " "
-	f.puts "-----"
-	f.puts test_epub_status
-	f.puts "----- ebook ISBN: #{Metadata.eisbn}"
-	f.puts "finished epubmaker"
-end
-
+@log_hash['print_ISBN']=Metadata.pisbn
 @log_hash['test_epub_status'] = test_epub_status
 
 # Write json log:

--- a/core/epubmaker/epubmaker.rb
+++ b/core/epubmaker/epubmaker.rb
@@ -400,7 +400,7 @@ else
 	test_epub_status = "FAIL: the EPUB was created successfully"
 end
 
-@log_hash['print_ISBN']=Metadata.pisbn
+@log_hash['ebook_ISBN']=Metadata.eisbn
 @log_hash['test_epub_status'] = test_epub_status
 
 # Write json log:

--- a/core/epubmaker/epubmaker.rb
+++ b/core/epubmaker/epubmaker.rb
@@ -28,7 +28,7 @@ epub_xsl = File.join(Bkmkr::Paths.scripts_dir, "HTMLBook", "htmlbook-xsl", "epub
 tmp_epub = File.join(Bkmkr::Paths.project_tmp_dir, "tmp.epub")
 
 # the path for the conversion log file
-convert_log_txt = File.join(Bkmkr::Paths.log_dir, "#{Bkmkr::Project.filename}.txt")
+convert_log_txt = File.join(Bkmkr::Paths.log_dir, "#{Bkmkr::Project.filename}-stdout-and-err.txt")
 
 # the path for the temp OEBPS dir
 oebps_dir = File.join(Bkmkr::Paths.project_tmp_dir, "OEBPS")
@@ -343,11 +343,10 @@ runNode_epubmaker(strip_tocnodes_js, epub_tmp_html, 'strip_tocnodes_js')
 
 # Add new section to log file
 File.open(convert_log_txt, 'a+') do |f|
-	f.puts "----- EPUBMAKER PROCESSES"
+	f.puts "----- EPUBMAKER XSL STDERR"
 end
 
 # convert to epub and send stderr to log file
-cdToProjectTmp('cd_to_project_tmpdir')
 processxsl_epubmaker(epub_tmp_html, epub_xsl, tmp_epub, convert_log_txt, 'process_xsl')
 
 # run method: firstCoverEdit

--- a/core/epubmaker/epubmaker.rb
+++ b/core/epubmaker/epubmaker.rb
@@ -27,9 +27,6 @@ epub_xsl = File.join(Bkmkr::Paths.scripts_dir, "HTMLBook", "htmlbook-xsl", "epub
 # the path for the temporary epub file
 tmp_epub = File.join(Bkmkr::Paths.project_tmp_dir, "tmp.epub")
 
-# the path for the conversion log file
-convert_log_txt = File.join(Bkmkr::Paths.log_dir, "#{Bkmkr::Project.filename}-stdout-and-err.txt")
-
 # the path for the temp OEBPS dir
 oebps_dir = File.join(Bkmkr::Paths.project_tmp_dir, "OEBPS")
 
@@ -152,8 +149,8 @@ ensure
 end
 
 ## wrapping Bkmkr::Tools.processxsl in a new method for this script; to return a result for json_logfile
-def processxsl_epubmaker(epub_tmp_html, epub_xsl, tmp_epub, convert_log_txt, logkey='')
-	Bkmkr::Tools.processxsl(epub_tmp_html, epub_xsl, tmp_epub, convert_log_txt)
+def processxsl_epubmaker(epub_tmp_html, epub_xsl, tmp_epub, logkey='')
+	Bkmkr::Tools.processxsl(epub_tmp_html, epub_xsl, tmp_epub, '')
 rescue => logstring
 ensure
     Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
@@ -341,13 +338,8 @@ overwriteFile(epub_tmp_html, filecontents, 'overwrite_epubtmp_html')
 
 runNode_epubmaker(strip_tocnodes_js, epub_tmp_html, 'strip_tocnodes_js')
 
-# Add new section to log file
-File.open(convert_log_txt, 'a+') do |f|
-	f.puts "----- EPUBMAKER XSL STDERR"
-end
-
-# convert to epub and send stderr to log file
-processxsl_epubmaker(epub_tmp_html, epub_xsl, tmp_epub, convert_log_txt, 'process_xsl')
+# convert to epub!
+processxsl_epubmaker(epub_tmp_html, epub_xsl, tmp_epub, 'process_xsl')
 
 # run method: firstCoverEdit
 # run method: firstNCXEdit

--- a/core/filearchive/filearchive.rb
+++ b/core/filearchive/filearchive.rb
@@ -64,15 +64,7 @@ copyFile(Bkmkr::Paths.outputtmp_html, final_html, 'copy_html_to_final_layout_dir
 
 copyFile(tmp_config, final_config, 'copy_tmp_config_final_layout_dir')
 
-
-# ---------------------- LOGGING
-
-# Printing the test results to the log file
-File.open(Bkmkr::Paths.log_file, 'a+') do |f|
-	f.puts "----- FILEARCHIVE PROCESSES"
-	f.puts "----- Print ISBN: #{Metadata.pisbn}"
-	f.puts "finished filearchive"
-end
+@log_hash['print_ISBN']=Metadata.pisbn
 
 # Write json log:
 Mcmlln::Tools.logtoJson(@log_hash, 'completed', Time.now)

--- a/core/header.rb
+++ b/core/header.rb
@@ -154,8 +154,13 @@ module Bkmkr
 		# for any script that calls this method:
 		# create 'local_log' hash nested in the jsonlog_hash named after the script basename
 		# add a 'begun' key/value to the new local hash
-		def self.setLocalLoghash
-		  local_log_hash = Bkmkr::Paths.jsonlog_hash
+		def self.setLocalLoghash(new_hash=false)
+			# if we receive optional new_hash value of 'true', we overwrite jsonlog contents & starting with a fresh new hash
+			unless new_hash == true
+		  	local_log_hash = Bkmkr::Paths.jsonlog_hash
+			else
+				local_log_hash = {}
+			end
 		  local_log_hash[Bkmkr::Paths.thisscript] = {'begun'=>Time.now}
 		  return local_log_hash, local_log_hash[Bkmkr::Paths.thisscript]
 		end

--- a/core/header.rb
+++ b/core/header.rb
@@ -212,10 +212,10 @@ module Bkmkr
 		def self.processxsl(html_file, xsl_file, epub_file, convert_log_txt)
 			if $xsl_processor
 				xsl_command = $xsl_processor.gsub(/\S*\.html/,"#{html_file}").gsub(/\S*\.xsl/,"#{xsl_file}").gsub(/\S*\.epub/,"#{epub_file}")
-				`#{xsl_command} 2>>"#{convert_log_txt}"`
+				`#{xsl_command}` #2>>"#{convert_log_txt}"`
 			else
 				saxonpath = File.join(Bkmkr::Paths.resource_dir, "saxon", "#{xslprocessor}.jar")
-				`java -jar "#{saxonpath}" -s:"#{html_file}" -xsl:"#{xsl_file}" -o:"#{epub_file}" 2>>"#{convert_log_txt}"`
+				`java -jar "#{saxonpath}" -s:"#{html_file}" -xsl:"#{xsl_file}" -o:"#{epub_file}"` # 2>>"#{convert_log_txt}"`
 			end
 		end
 

--- a/core/htmlmaker/htmlmaker.rb
+++ b/core/htmlmaker/htmlmaker.rb
@@ -202,27 +202,16 @@ htmlmakerRunNode(title_js, "#{Bkmkr::Paths.outputtmp_html} \"#{Metadata.booktitl
 # evaluate processing instructions
 htmlmakerRunNode(evaluate_pis, Bkmkr::Paths.outputtmp_html, 'evaluate_pis')
 
-# ---------------------- LOGGING
-
 # html file should exist
 if File.file?("#{Bkmkr::Paths.outputtmp_html}")
 	test_html_status = "pass: html file was created successfully"
 else
 	test_html_status = "FAIL: html file was created successfully"
 end
+@log_hash['html_status']=test_html_status
 
-# wrapping this legacy log in a begin block so it doesn't hose travis tests.
-begin
-	# Printing the test results to the log file
-	File.open("#{Bkmkr::Paths.log_file}", 'a+') do |f|
-		f.puts "----- HTMLMAKER PROCESSES"
-		f.puts test_html_status
-		f.puts "finished htmlmaker"
-	end
-rescue => e
- 	puts '(Ignore for unit-tests:) ERROR encountered in process block: ', e
-end
 
+# ---------------------- LOGGING
 # Write json log:
 Mcmlln::Tools.logtoJson(@log_hash, 'completed', Time.now)
 Mcmlln::Tools.write_json(local_log_hash, Bkmkr::Paths.json_log)

--- a/core/imagechecker/imagechecker.rb
+++ b/core/imagechecker/imagechecker.rb
@@ -195,31 +195,16 @@ writeMissingErrors(missing, image_error, 'write_missing_errors')
 # run method: writeResErrors
 writeResErrors(resolution, image_error, 'write_resolution_errors')
 
+
+# ---------------------- LOGGING
+
 # write items of interest to json log
+@log_hash['image_references_in_ms']=imgarr.count
 @log_hash['imagedir_images'] = images
 @log_hash['finaldir_images'] = finalimages
 @log_hash['unique_image_array'] = imgarr
 @log_hash['lowres_images'] = resolution
 @log_hash['missing_images'] = missing
-
-# ---------------------- LOGGING
-
-# Count how many images are referenced in the book
-test_img_src = imgarr.count
-
-if missing.any?
-	test_missing_img = "FAIL: These image files seem to be missing: #{missing}"
-else
-	test_missing_img = "pass: There are no missing image files!"
-end
-
-# Printing the test results to the log file
-File.open(Bkmkr::Paths.log_file, 'a+') do |f|
-	f.puts "----- IMAGECHECKER PROCESSES"
-	f.puts "I found #{test_img_src} image references in this book"
-	f.puts "#{test_missing_img}"
-	f.puts "finished imagechecker"
-end
 
 # Write json log:
 Mcmlln::Tools.logtoJson(@log_hash, 'completed', Time.now)

--- a/core/pdfmaker/pdfmaker.rb
+++ b/core/pdfmaker/pdfmaker.rb
@@ -182,21 +182,6 @@ overwriteFile(cssfile, revertcss, 'overwrite_css_rm-ing_escapechars')
 
 # ---------------------- LOGGING
 
-# is there custom javascript?
-
-if File.file?(Metadata.printjs)
-	test_custom_js = Metadata.printjs
-else
-	test_custom_js = "none"
-end
-
-# Printing the test results to the log file
-File.open(Bkmkr::Paths.log_file, 'a+') do |f|
-	f.puts "----- PDFMAKER PROCESSES"
-	f.puts "----- I found the following custom javascript: #{test_custom_js}"
-	f.puts "finished pdfmaker"
-end
-
 # Write json log:
 Mcmlln::Tools.logtoJson(@log_hash, 'completed', Time.now)
 Mcmlln::Tools.write_json(local_log_hash, Bkmkr::Paths.json_log)

--- a/core/stylesheets/stylesheets.rb
+++ b/core/stylesheets/stylesheets.rb
@@ -262,15 +262,6 @@ evalOneoffs("oneoff_epub.css", tmp_epub_css, 'one_off_css_for_epub')
 
 # ---------------------- LOGGING
 
-# Printing the test results to the log file
-File.open(Bkmkr::Paths.log_file, 'a+') do |f|
-	f.puts "----- STYLESHEETS PROCESSES"
-	f.puts "----- I found #{@log_hash['chapter_head_count']} chapters in this book."
-	f.puts @log_hash['evaluate_Trim_PIs']
-	f.puts @log_hash['evaluate_Toc_PIs']
-	f.puts "finished stylesheets"
-end
-
 # Write json log:
 Mcmlln::Tools.logtoJson(@log_hash, 'completed', Time.now)
 Mcmlln::Tools.write_json(local_log_hash, Bkmkr::Paths.json_log)

--- a/core/tmparchive/tmparchive.rb
+++ b/core/tmparchive/tmparchive.rb
@@ -3,7 +3,7 @@ require 'fileutils'
 require_relative '../header.rb'
 
 # ---------------------- VARIABLES
-local_log_hash, @log_hash = Bkmkr::Paths.setLocalLoghash
+local_log_hash, @log_hash = Bkmkr::Paths.setLocalLoghash(true)
 
 input_config = File.join(Bkmkr::Paths.submitted_images, "config.json")
 
@@ -92,15 +92,6 @@ filecontents = "The conversion processor is currently running. Please do not sub
 writeAlertFile(filecontents, 'write_alert_file')
 
 # ---------------------- LOGGING
-
-# Write test results
-File.open("#{Bkmkr::Paths.log_file}", 'w+') do |f|
-	f.puts "-----"
-	f.puts Time.now
-	f.puts "----- TMPARCHIVE PROCESSES"
-	f.puts "finished tmparchive"
-end
-
 # Write json log:
 Mcmlln::Tools.logtoJson(@log_hash, 'completed', Time.now)
 Mcmlln::Tools.write_json(local_log_hash, Bkmkr::Paths.json_log)


### PR DESCRIPTION
All of this is pretty straightforward except for stuff in header.rb & epubmaker.rb:

- In the header, I added a provision to the jsonlog method so when invoked from tmparchive.rb it will clear old contents of the jsonlog hash
- Epubmaker's call to the processxsl method in the header was logging to the old logfile. I tried logging to the stderr-out.txt file instead, but the deploy.bat is using the file already so ruby can't open it.  I settled for keeping the parameter in the method itself but passing it an empty string from epubmaker, and removing the output redirect from the shell commands in the header...  so now the output from xsl transformations end up in the stderr-out.txt file anyways.