### PR TITLE
Adjusting prince command for windows

### DIFF
--- a/core/header.rb
+++ b/core/header.rb
@@ -245,8 +245,14 @@ module Bkmkr
 
 		def self.makepdf(pdfprocessor, pisbn, pdf_html_file, pdf_html, pdf_css, testing_value, http_username, http_password)
 			pdffile = File.join(Paths.project_tmp_dir, "#{pisbn}.pdf")
+			if os == "mac" or os == "unix"
+				princecmd = "prince"
+			elsif os == "windows"
+				princecmd = File.join(Paths.resource_dir, "Program Files (x86)", "Prince", "engine", "bin", "prince.exe")
+				princecmd = "\"#{princecmd}\""
+			end
 			if pdfprocessor == "prince"
-				`prince -s #{pdf_css} --javascript #{pdf_html_file} -o #{pdffile}`
+				`#{princecmd} -s \"#{pdf_css}\" --javascript --http-user=#{http_username} --http-password=#{http_password} \"#{pdf_html_file}\" -o \"#{pdffile}\"`
 			elsif pdfprocessor == "docraptor"
 				File.open(pdffile, "w+b") do |f|
 				f.write DocRaptor.create(:document_content => pdf_html,


### PR DESCRIPTION
Adding config values to the pdfmaker prince command, so it works on both mac and windows. Tested locally and on staging.