### PR TITLE
Adding handling for figs duplicating ids

### DIFF
--- a/core/htmlmaker/bandaid.js
+++ b/core/htmlmaker/bandaid.js
@@ -25,8 +25,10 @@ fs.readFile(file, function processTemplates (err, contents) {
   // fix fig ids in case of duplication
   $('figure').each(function(){
     var myId = $(this).attr('id');
-    var newId = "fig-" + myId;
-    $(this).attr('id', newId);
+    if ( myId !== undefined ) {
+      var newId = "fig-" + myId;
+      $(this).attr('id', newId); 
+    }
   });
 
   var output = $.html();

--- a/core/htmlmaker/bandaid.js
+++ b/core/htmlmaker/bandaid.js
@@ -22,6 +22,13 @@ fs.readFile(file, function processTemplates (err, contents) {
   $('blockquote + p.SpaceBreak-Internalint, aside + p.SpaceBreak-Internalint, pre + p.SpaceBreak-Internalint').remove();
   $('blockquote + p.BookmakerProcessingInstructionbpi, aside + p.BookmakerProcessingInstructionbpi, pre + p.BookmakerProcessingInstructionbpi').remove();
 
+  // fix fig ids in case of duplication
+  $('figure').each(function(){
+    var myId = $(this).attr('id');
+    var newId = "fig-" + myId;
+    $(this).attr('id', newId);
+  });
+
   var output = $.html();
     fs.writeFile(file, output, function(err) {
 	    if(err) {


### PR DESCRIPTION
With the current XSL conversion, figure elements occasionally duplicate the id of a previous sibling or parent. Adding a little patch to force fig ids to be unique. I expect this will be fixed for real in the htmlmaker_js.

@mattretzer can you review?