### PR TITLE
Templateversion

### DIFF
--- a/core/htmlmaker/htmlmaker.rb
+++ b/core/htmlmaker/htmlmaker.rb
@@ -66,7 +66,7 @@ def versionCompare(v1, v2, logkey='')
     logstring = "template_version is empty, indicating an html file, no conversion necessary"
     return true
   elsif v1.match(/[^\d.]/) || v2.match(/[^\d.]/)
-    logstring = "template_version string includes nondigit chars: returning false for xsl conversion"
+    logstring = "template_version string includes nondigit chars: returning false, xsl conversion"
     return false
   elsif v1 == v2
     logstring = "template_version meets requirements for jsconvert"
@@ -83,7 +83,7 @@ def versionCompare(v1, v2, logkey='')
         logstring = "template_version meets requirements for jsconvert"
         return true
       elsif v1split < v2split
-        logstring = "template_version is older than required version for jsconvert: returning false for xsl conversion"
+        logstring = "template_version is older than required version for jsconvert: returning false, xsl conversion"
         return false
       elsif n == maxlength-1 && v1split == v2split
         logstring = "template_version meets requirements for jsconvert"

--- a/core/htmlmaker/htmlmaker.rb
+++ b/core/htmlmaker/htmlmaker.rb
@@ -48,22 +48,13 @@ preformatted_js = File.join(Bkmkr::Paths.core_dir, "htmlmaker", "preformatted.js
 
 # ---------------------- METHODS
 
-def readConfigJson(logkey='')
-  data_hash = Mcmlln::Tools.readjson(Metadata.configfile)
-  return data_hash
-rescue => logstring
-  return {}
-ensure
-  Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
-end
-
 # returns true if v1 is nil, empty, or >= v2. Otherwise returns false
 def versionCompare(v1, v2, logkey='')
   if v1.nil?
-    logstring = "template_version is nil, indicating a non-Macmillan bookmaker instance; returning 'true' for js conversion"
+    logstring = "template_version is nil; htmlmaker_preprocessing.rb may have crashed? proceeding with js conversion"
     return true
   elsif v1.empty?
-    logstring = "template_version is empty, indicating an html file, no conversion necessary"
+    logstring = "template_version is empty; input file is html or this is a non-Macmillan bookmaker instance"
     return true
   elsif v1.match(/[^\d.]/) || v2.match(/[^\d.]/)
     logstring = "template_version string includes nondigit chars: returning false, xsl conversion"
@@ -211,32 +202,28 @@ end
 
 # ---------------------- PROCESSES
 
-# get template_version value from config.json.
-data_hash = readConfigJson('read_config_json')
-# If no config.json file is present or it does not have a 'template_version' key, this value will be nil:
-template_version = data_hash['template_version']
+# get template_version value from json logfile (local_log_hash is a hash of the json logfile, read in at the beginning of each script)
+if local_log_hash.key?('htmlmaker_preprocessing.rb')
+  template_version = local_log_hash['htmlmaker_preprocessing.rb']['template_version']
+else
+  # if htmlmaker_preprocessing.rb was not run, set this value to an empty string
+  template_version = ''
+end
 
-# this method will return true if:
-#   template_version is nil (this would be the case if htmlpreprocessing.rb was not run, as in the case of a non-Macmillan bookmaker-instance),
-#   template_version is empty (this would be the case when the input file is an html file)
-#   template_version >= required_version_for_jsconvert
-# it will return false if
-#   template_version < required_version_for_jsconvert
-#   template_version is 'not-found' or has any other non-digit or characters (besides '.')
+# the versionCompare method returns true if:  template_version is empty, or if template_version >= required_version_for_jsconvert
+# it returns false if: template_version < required_version_for_jsconvert, or if template_version has any non-digit characters (besides '.')
 htmlmaker_js_version_test = versionCompare(template_version, required_version_for_jsconvert, 'version_compare')
 @log_hash['htmlmaker_js_version_test'] = htmlmaker_js_version_test
 
-# convert a .docx tp HTML, via js or xsl: depending on value of htmlmaker_js_version_test from above
+# if htmlmaker_js_version_test is true, convert .docx to HTML via js
 if htmlmaker_js_version_test == true
-  # if infile is docx, convert to htmlbook html & generate TOC; otherwise bypass
-  # else, if infile is already html, rename a copy of file to 'outputtmp.html'
+
+  # if the docx file exists, convert to html via js
   if File.file?(Bkmkr::Paths.project_docx_file)
+    # convert to html via htmlmaker_js
     htmlmakerRunNode(htmlmaker, "#{Bkmkr::Paths.project_docx_file} #{Bkmkr::Paths.project_tmp_dir} #{styles_json} #{stylefunctions_js}", 'convertdocx_to_html')
 
     # make copy of output html to match name 'outputtmp_html'
-    # <<this is a quick workaround, since htmlmaker_js outputs an html file with basename matching in-file..
-    # .. and subsequent items in the toolchain expect outputtmp.html
-    # Another alternative would be set outputtmp_html in header.rb to match project_html_file below: >>
     copyFile(project_html_file, Bkmkr::Paths.outputtmp_html, 'copy_and_rename_html_to_outputtmphtml')
 
     # convert html to htmlbook
@@ -246,9 +233,12 @@ if htmlmaker_js_version_test == true
     htmlmakerRunNode(generateTOC_js, Bkmkr::Paths.outputtmp_html, 'generateTOC_js')
 
   elsif File.file?(project_html_file)
+
+    # if infile was already html, rename a copy of file to 'outputtmp.html'
     copyFile(project_html_file, Bkmkr::Paths.outputtmp_html, 'copy_and_rename_html_to_outputtmphtml')
   end
 
+# if htmlmaker_js_version_test is false, convert .docx to HTML via xsl
 elsif htmlmaker_js_version_test == false
 
   # convert docx to xml

--- a/core/htmlmaker/htmlmaker.rb
+++ b/core/htmlmaker/htmlmaker.rb
@@ -34,6 +34,8 @@ generateTOC_js = File.join(htmlmakerjs_path, 'lib', 'generateTOC.js')
 
 headings_js = File.join(Bkmkr::Paths.core_dir, "htmlmaker", "headings.js")
 
+xsl_js = File.join(Bkmkr::Paths.core_dir, "htmlmaker", "xsl_only.js")
+
 inlines_js = File.join(Bkmkr::Paths.core_dir, "htmlmaker", "inlines.js")
 
 evaluate_pis = File.join(Bkmkr::Paths.core_dir, "htmlmaker", "evaluate_pis.js")
@@ -222,6 +224,7 @@ template_version = data_hash['template_version']
 #   template_version < required_version_for_jsconvert
 #   template_version is 'not-found' or has any other non-digit or characters (besides '.')
 htmlmaker_js_version_test = versionCompare(template_version, required_version_for_jsconvert, 'version_compare')
+@log_hash['htmlmaker_js_version_test'] = htmlmaker_js_version_test
 
 # convert a .docx tp HTML, via js or xsl: depending on value of htmlmaker_js_version_test from above
 if htmlmaker_js_version_test == true
@@ -270,8 +273,18 @@ filecontents = fixEntities(filecontents, 'fix_entities')
 #write out edited html
 overwriteFile(Bkmkr::Paths.outputtmp_html, filecontents, 'overwrite_output_html_a')
 
-# # add headings to all sections
-htmlmakerRunNode(headings_js, Bkmkr::Paths.outputtmp_html, 'headings_js')
+if htmlmaker_js_version_test == true
+
+  # # add headings to all sections
+  htmlmakerRunNode(headings_js, Bkmkr::Paths.outputtmp_html, 'headings_js')
+
+elsif htmlmaker_js_version_test == false
+
+  # # run supplemental js transformations for the xsl-conversion, consolidating legacy files:
+  # #   footnotes.js, strip-toc.js, parts.js, headings.js, lists.js, + 1 item from bandaid.js
+  htmlmakerRunNode(xsl_js, Bkmkr::Paths.outputtmp_html, 'xsl_only_js')
+
+end
 
 # # add correct markup for inlines (em, strong, sup, sub)
 htmlmakerRunNode(inlines_js, Bkmkr::Paths.outputtmp_html, 'inlines_js')

--- a/core/htmlmaker/htmlmaker.rb
+++ b/core/htmlmaker/htmlmaker.rb
@@ -40,6 +40,8 @@ evaluate_pis = File.join(Bkmkr::Paths.core_dir, "htmlmaker", "evaluate_pis.js")
 
 title_js = File.join(Bkmkr::Paths.core_dir, "htmlmaker", "title.js")
 
+version_metatag_js = File.join(Bkmkr::Paths.core_dir, "htmlmaker", "templateversion_metatag.js")
+
 preformatted_js = File.join(Bkmkr::Paths.core_dir, "htmlmaker", "preformatted.js")
 
 # ---------------------- METHODS
@@ -286,6 +288,11 @@ overwriteFile(Bkmkr::Paths.outputtmp_html, filecontents, 'overwrite_output_html_
 
 # set html title to match JSON
 htmlmakerRunNode(title_js, "#{Bkmkr::Paths.outputtmp_html} \"#{Metadata.booktitle}\"", 'title_js')
+
+# add meta tag to html with template_version
+unless template_version.nil? || template_version.empty?
+  htmlmakerRunNode(version_metatag_js, "#{Bkmkr::Paths.outputtmp_html} \"#{template_version}\"", 'add_template-version_meta_tag')
+end
 
 # evaluate processing instructions
 htmlmakerRunNode(evaluate_pis, Bkmkr::Paths.outputtmp_html, 'evaluate_pis')

--- a/core/htmlmaker/htmlmaker.rb
+++ b/core/htmlmaker/htmlmaker.rb
@@ -40,7 +40,7 @@ evaluate_pis = File.join(Bkmkr::Paths.core_dir, "htmlmaker", "evaluate_pis.js")
 
 title_js = File.join(Bkmkr::Paths.core_dir, "htmlmaker", "title.js")
 
-version_metatag_js = File.join(Bkmkr::Paths.core_dir, "htmlmaker", "templateversion_metatag.js")
+version_metatag_js = File.join(Bkmkr::Paths.core_dir, "htmlmaker", "version_metatag.js")
 
 preformatted_js = File.join(Bkmkr::Paths.core_dir, "htmlmaker", "preformatted.js")
 

--- a/core/htmlmaker/htmlmaker.rb
+++ b/core/htmlmaker/htmlmaker.rb
@@ -8,13 +8,15 @@ local_log_hash, @log_hash = Bkmkr::Paths.setLocalLoghash
 
 filetype = Bkmkr::Project.filename_split.split(".").pop
 
-# saxonpath = File.join(Bkmkr::Paths.resource_dir, "saxon", "#{Bkmkr::Tools.xslprocessor}.jar")
+saxonpath = File.join(Bkmkr::Paths.resource_dir, "saxon", "#{Bkmkr::Tools.xslprocessor}.jar")
 
-# docxtoxml_py = File.join(Bkmkr::Paths.core_dir, "htmlmaker", "docxtoxml.py")
+docxtoxml_py = File.join(Bkmkr::Paths.core_dir, "htmlmaker", "docxtoxml.py")
 
-# source_xml = File.join(Bkmkr::Paths.project_tmp_dir, "#{Bkmkr::Project.filename}.xml")
+source_xml = File.join(Bkmkr::Paths.project_tmp_dir, "#{Bkmkr::Project.filename}.xml")
 
-# word_to_html_xsl = File.join(Bkmkr::Paths.core_dir, "htmlmaker", "wordtohtml.xsl")
+word_to_html_xsl = File.join(Bkmkr::Paths.core_dir, "htmlmaker", "wordtohtml.xsl")
+
+project_html_file = File.join(Bkmkr::Paths.project_tmp_dir, "#{Bkmkr::Project.filename}.html")
 
 htmlmakerjs_path = File.join(Bkmkr::Paths.scripts_dir, "htmlmaker_js")
 
@@ -40,29 +42,38 @@ preformatted_js = File.join(Bkmkr::Paths.core_dir, "htmlmaker", "preformatted.js
 
 # ---------------------- METHODS
 
-# ## wrapping Bkmkr::Tools.runpython in a new method for this script; to return a result for json_logfile
-# def convertdocxtoxml(filetype, docxtoxml_py, logkey='')
-# 	unless filetype == "html"
-# 		Bkmkr::Tools.runpython(docxtoxml_py, Bkmkr::Paths.project_docx_file)
-# 	else
-# 		logstring = 'input file is html, skipping'
-# 	end
-# rescue => logstring
-# ensure
-# 	Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
-# end
+def readConfigJson(logkey='')
+  data_hash = Mcmlln::Tools.readjson(Metadata.configfile)
+  return data_hash
+rescue => logstring
+  return {}
+ensure
+  Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+end
 
-# def convertxmltohtml(filetype, saxonpath, source_xml, word_to_html_xsl, logkey='')
-# 	unless filetype == "html"
-# 		`java -jar "#{saxonpath}" -s:"#{source_xml}" -xsl:"#{word_to_html_xsl}" -o:"#{Bkmkr::Paths.outputtmp_html}"`
-# 	else
-# 		Mcmlln::Tools.copyFile(Bkmkr::Paths.project_tmp_file, Bkmkr::Paths.outputtmp_html)
-# 		logstring = 'input file is html, skipping (copied input file to project_tmp)'
-# 	end
-# rescue => logstring
-# ensure
-# 	Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
-# end
+## wrapping Bkmkr::Tools.runpython in a new method for this script; to return a result for json_logfile
+def convertdocxtoxml(filetype, docxtoxml_py, logkey='')
+	unless filetype == "html"
+		Bkmkr::Tools.runpython(docxtoxml_py, Bkmkr::Paths.project_docx_file)
+	else
+		logstring = 'input file is html, skipping'
+	end
+rescue => logstring
+ensure
+	Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+end
+
+def convertxmltohtml(filetype, saxonpath, source_xml, word_to_html_xsl, logkey='')
+	unless filetype == "html"
+		`java -jar "#{saxonpath}" -s:"#{source_xml}" -xsl:"#{word_to_html_xsl}" -o:"#{Bkmkr::Paths.outputtmp_html}"`
+	else
+		Mcmlln::Tools.copyFile(Bkmkr::Paths.project_tmp_file, Bkmkr::Paths.outputtmp_html)
+		logstring = 'input file is html, skipping (copied input file to project_tmp)'
+	end
+rescue => logstring
+ensure
+	Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+end
 
 ## wrapping Bkmkr::Tools.runnode in a new method for this script; to return a result for json_logfile
 def htmlmakerRunNode(jsfile, args, logkey='')
@@ -153,34 +164,43 @@ ensure
 end
 
 # ---------------------- PROCESSES
-# # convert docx to xml
-# convertdocxtoxml(filetype, docxtoxml_py, 'convert_docx_to_xml')
-#
-# # convert xml to html
-# convertxmltohtml(filetype, saxonpath, source_xml, word_to_html_xsl, 'convert_xml_to_html')
 
+# get template_version value from config.json.
+data_hash = readConfigJson('read_config_json')
+# If no config.json file is present or it does not have a 'template_version' key, this value will be nil:
+template_version = data_hash['template_version']
 
-project_html_file = File.join(Bkmkr::Paths.project_tmp_dir, "#{Bkmkr::Project.filename}.html")
+# convert docx to HTML using htmlmaker_js unless the docx template_version was checked and no value was found
+unless template_version == 'not_found'
 
-# if infile is docx, convert to htmlbook html & generate TOC; otherwise bypass
-# elsif infile is already html, make a copy of file named outputtmp.html
-if File.file?(Bkmkr::Paths.project_docx_file)
-  htmlmakerRunNode(htmlmaker, "#{Bkmkr::Paths.project_docx_file} #{Bkmkr::Paths.project_tmp_dir} #{styles_json} #{stylefunctions_js}", 'convertdocx_to_html')
+  # if infile is docx, convert to htmlbook html & generate TOC; otherwise bypass
+  # else, if infile is already html, rename a copy of file to 'outputtmp.html'
+  if File.file?(Bkmkr::Paths.project_docx_file)
+    htmlmakerRunNode(htmlmaker, "#{Bkmkr::Paths.project_docx_file} #{Bkmkr::Paths.project_tmp_dir} #{styles_json} #{stylefunctions_js}", 'convertdocx_to_html')
 
-  # make copy of output html to match name 'outputtmp_html'
-  # <<this is a quick workaround, since htmlmaker_js outputs an html file with basename matching in-file..
-  # .. and subsequent items in the toolchain expect outputtmp.html
-  # Another alternative would be set outputtmp_html in header.rb to match project_html_file below: >>
-  copyFile(project_html_file, Bkmkr::Paths.outputtmp_html, 'copy_and_rename_html_to_outputtmphtml')
+    # make copy of output html to match name 'outputtmp_html'
+    # <<this is a quick workaround, since htmlmaker_js outputs an html file with basename matching in-file..
+    # .. and subsequent items in the toolchain expect outputtmp.html
+    # Another alternative would be set outputtmp_html in header.rb to match project_html_file below: >>
+    copyFile(project_html_file, Bkmkr::Paths.outputtmp_html, 'copy_and_rename_html_to_outputtmphtml')
 
-  # convert html to htmlbook
-  htmlmakerRunNode(htmltohtmlbook_js, Bkmkr::Paths.outputtmp_html, 'convert_to_htmlbook')
+    # convert html to htmlbook
+    htmlmakerRunNode(htmltohtmlbook_js, Bkmkr::Paths.outputtmp_html, 'convert_to_htmlbook')
 
-  # generateTOC
-  htmlmakerRunNode(generateTOC_js, Bkmkr::Paths.outputtmp_html, 'generateTOC_js')
+    # generateTOC
+    htmlmakerRunNode(generateTOC_js, Bkmkr::Paths.outputtmp_html, 'generateTOC_js')
 
-elsif File.file?(project_html_file)
-  copyFile(project_html_file, Bkmkr::Paths.outputtmp_html, 'copy_and_rename_html_to_outputtmphtml')
+  elsif File.file?(project_html_file)
+    copyFile(project_html_file, Bkmkr::Paths.outputtmp_html, 'copy_and_rename_html_to_outputtmphtml')
+  end
+
+else  # template_version was checked and no value found, indicating a .docx styled pre-Section-Starts: convert to HTML with xsl
+
+  # convert docx to xml
+  convertdocxtoxml(filetype, docxtoxml_py, 'convert_docx_to_xml')
+
+  # convert xml to html
+  convertxmltohtml(filetype, saxonpath, source_xml, word_to_html_xsl, 'convert_xml_to_html')
 end
 
 # read in html

--- a/core/htmlmaker/version_metatag.js
+++ b/core/htmlmaker/version_metatag.js
@@ -1,0 +1,25 @@
+var fs = require('fs');
+var cheerio = require('cheerio');
+var file = process.argv[2];
+var templateversion = process.argv[3];
+
+fs.readFile(file, function processTemplates (err, contents) {
+  $ = cheerio.load(contents, {
+          xmlMode: true
+        });
+
+  // add meta info for template_version
+  var metatemplateversion = '<meta name="templateversion" content="' + templateversion + '"/>';
+
+  $('head').append(metatemplateversion);
+
+
+  var output = $.html();
+    fs.writeFile(file, output, function(err) {
+	    if(err) {
+	        return console.log(err);
+	    }
+
+	    console.log("Processing instructions have been evaluated!");
+	});
+});

--- a/core/htmlmaker/xsl_only.js
+++ b/core/htmlmaker/xsl_only.js
@@ -1,0 +1,136 @@
+var fs = require('fs');
+var cheerio = require('cheerio');
+var file = process.argv[2];
+
+fs.readFile(file, function processTemplates (err, contents) {
+  $ = cheerio.load(contents, {
+          xmlMode: true
+        });
+
+//function to replace element, keeping innerHtml & attributes
+function replaceEl (selector, newTag) {
+  selector.each(function(){
+    var myAttr = $(this).attr();
+    var myHtml = $(this).html();
+    $(this).replaceWith(function(){
+        return $(newTag).html(myHtml).attr(myAttr);
+    });
+  });
+}
+
+///////////////////////////// FOOTNOTES
+//select <p>s nested in spans with data-type 'footnote'
+var footnoteNestedP = $("span[data-type='footnote'] p");
+//call function, replace selected <p>s to spans
+replaceEl (footnoteNestedP, "<span data-type='footnote' />");
+//remove unwanted sections/ empty divs put there by Word
+$("section[data-type='footnotes']").remove();
+$("#endnotetext-0").remove();
+$("#endnotetext--1").remove();
+
+
+///////////////////////////// STRIP-TOC
+//addClass to 'preface' section (with h1 text containing 'Contents')
+$("section[data-type='preface']>h1:contains('Contents')").parents("section").addClass('texttoc');
+$("section[data-type='preface']>h1:contains('CONTENTS')").parents("section").addClass('texttoc');
+$("section[data-type='preface']>p[class^='TOC']").parents("section").addClass('texttoc');
+
+
+///////////////////////////// PARTS
+//select sections with data-type 'part'
+var datatypePart = $("section[data-type='part']");
+//change them to 'div's
+replaceEl (datatypePart, "<div />");
+
+
+//////////////////////////// HEADINGS
+//select sections without first-child h1's
+var noHeadSection = $("section:not(:has(h1:first-child))");
+//select sections' nested elements (<p>s, h1's) with classes or text matching key criteria
+var ataSection = $("section").find("p.AboutAuthorTextNo-Indentatatx1,p.AboutAuthorTextHeadatah,p.AboutAuthorTextatatx,h1:contains(About the Author)");
+var bobadSection = $("section").find("h1.BOBAdTitlebobt,p.BOBAdTextbobtx")
+var fsSection = $("section").find("p.FrontSalesTitlefst,p.FrontSalesSubtitlefsst,p.FrontSalesQuoteHeadfsqh,p.FrontSalesTextfstx,p.FrontSalesTextNoIndentfstx1,p.FrontSalesQuotefsq,p.FrontSalesQuoteNoIndentfsq1")
+
+//for each section without first-child h1's, create one with .Nonprinting and approporate h1 text
+noHeadSection.each (function() {
+  var hText = "Frontmatter";
+    if ($(".CopyrightTextsinglespacecrtx", this).length || $(".CopyrightTextdoublespacecrtxd", this).length) {
+      hText = "Copyright Page";
+    }
+    if ($(".Dedicationded", this).length) {
+      hText = "Dedication";
+    }
+    if ($(".AdCardMainHeadacmh", this).length || $(".AdCardSubheadacsh", this).length || $(".AdCardListofTitlesacl", this).length) {
+      hText = "Ad Card";
+    }
+    if ($(".AboutAuthorTextNo-Indentatatx1", this).length || $(".AboutAuthorTextHeadatah", this).length || $(".AboutAuthorTextatatx", this).length) {
+      hText = "About the Author";
+    }
+    if ($(".FrontSalesSubtitlefsst", this).length || $(".FrontSalesQuoteHeadfsqh", this).length || $(".FrontSalesTextfstx", this).length || $(".FrontSalesTextNoIndentfstx1", this).length || $(".FrontSalesQuotefsq", this).length || $(".FrontSalesQuoteNoIndentfsq1", this).length) {
+      hText = "Praise";
+    }
+  $(this).prepend("<h1 class='Nonprinting'>"+hText+"</h1>");
+});
+//addClass for sections containing related selections
+ataSection.each(function() {
+  $(this).parents("section").addClass("abouttheauthor");
+});
+bobadSection.each(function() {
+  $(this).parents("section").addClass("bobad");
+});
+fsSection.each(function() {
+  $(this).parents("section").addClass("frontsales");
+});
+
+
+///////////////////////////// LISTS
+//function to wrap lists in parent ul
+function tagLists (myclass, listtype) {
+  $( "p." + myclass ).wrap("<li class='" + myclass + "'></li>");
+
+  $( "li." + myclass ).wrap("<" + listtype + " class='" + myclass + "'></" + listtype + ">");
+
+  $(listtype + "." + myclass).each(function () {
+      var that = this.previousSibling;
+      var thisclass = $(this).attr('class');
+      var previousclass = $(that).attr('class');
+      if ((that && that.nodeType === 1 && that.tagName === this.tagName && typeof $(that).attr('class') !== 'undefined' && thisclass === previousclass)) {
+        var mytag = this.tagName.toString();
+        var el = $("<" + mytag + "/>").addClass("temp");
+        $(this).after(el);
+        var node = $(".temp");
+        while (that.firstChild) {
+            node.append(that.firstChild);
+        }
+        while (this.firstChild) {
+            node.append(this.firstChild);
+        }
+        $(that).remove();
+        $(this).remove();
+      }
+      $(".temp").addClass(thisclass).removeClass("temp");
+    });
+}
+
+tagLists ("Extract-BulletListextbl", "ul");
+tagLists ("SidebarListBulletsbbl", "ul");
+tagLists ("SidebarListNumsbnl", "ol");
+tagLists ("BoxListBulletbbl", "ul");
+tagLists ("BoxListNumbnl", "ol");
+
+
+///////////////////////////// from BANDAID.js
+// paragraphs to remove after conversion
+$('blockquote + p.SpaceBreak-Internalint, aside + p.SpaceBreak-Internalint, pre + p.SpaceBreak-Internalint').remove();
+$('blockquote + p.BookmakerProcessingInstructionbpi, aside + p.BookmakerProcessingInstructionbpi, pre + p.BookmakerProcessingInstructionbpi').remove();
+
+
+  var output = $.html();
+    fs.writeFile(file, output, function(err) {
+	    if(err) {
+	        return console.log(err);
+	    }
+
+      console.log("Processing instructions have been evaluated!");
+	});
+});


### PR DESCRIPTION
Hi @nelliemckesson ,  this PR, together with its [companion PR in addons](https://github.com/macmillanpublishers/bookmaker_addons/pull/158), include:
- the template version check, 
- edits to htmlmaker.rb so it chooses js or xsl conversion based on the template_version
- and some of the old js code, consolidated & re-added, to support the xsl conversion.

One comment/question:
In htmlmakerpreprocessing.rb I am writing the template_version-string to the config.json file.
htmlmaker.rb then scoops up this value from the config.json file and writes it into the html as a meta element.
However when metadatapreprocessing.rb runs, it overwrites the existing config.json, so that value is no longer in config.json.  It doesn’t matter functionally; I could also re-write the value in metadatapreprocessing if we wanted.
I could also read the value from the json logfile instead and skip using the config.json entirely?  I did read a value from the jsonlog output of htmlmaker.rb to detect js vs xsl conversion in metadata_preprocessing.rb.  Let me know what you think:)
