### PR TITLE
Singlerun lock

### DIFF
--- a/core/cleanup/cleanup.rb
+++ b/core/cleanup/cleanup.rb
@@ -41,9 +41,10 @@ ensure
 end
 
 ## wrapping a Mcmlln::Tools method in a new method for this script; to return a result for json_logfile
-def deleteFileifExists(file, logkey='')
-	if File.file?(file)
-		Mcmlln::Tools.deleteFile(file)
+def deleteFileifExists(logkey='')
+  donedir_lockfile_pathroot = File.join(Metadata.final_dir, "layout", "lockfile_*.txt")
+  if !Dir.glob(donedir_lockfile_pathroot).empty?
+		Mcmlln::Tools.deleteFile(Dir.glob(donedir_lockfile_pathroot)[0])
 	else
 		logstring = 'n-a'
 	end
@@ -67,6 +68,8 @@ deleteProjectTmpDir('delete_project_tmp_folder')
 deleteFileifExists(Bkmkr::Project.input_file, 'delete_input_file')
 
 deleteFileifExists(Bkmkr::Paths.alert, 'delete_alert_file')
+
+deleteFileifExists('delete_final_dir_lockfile')
 
 # ---------------------- LOGGING
 # Write json log:

--- a/core/cleanup/cleanup.rb
+++ b/core/cleanup/cleanup.rb
@@ -4,7 +4,9 @@ require_relative '../metadata.rb'
 # ---------------------- VARIABLES
 local_log_hash, @log_hash = Bkmkr::Paths.setLocalLoghash
 
-unused_submitted_dir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "unused_submitted_files")
+final_dir = Metadata.final_dir
+
+unused_submitted_dir = File.join(final_dir, "unused_submitted_files")
 
 # ---------------------- METHODS
 def readConfigJson(logkey='')
@@ -41,8 +43,20 @@ ensure
 end
 
 ## wrapping a Mcmlln::Tools method in a new method for this script; to return a result for json_logfile
-def deleteFileifExists(logkey='')
-  donedir_lockfile_pathroot = File.join(Metadata.final_dir, "layout", "lockfile_*.txt")
+def deleteFileifExists(file, logkey='')
+	if File.file?(file)
+		Mcmlln::Tools.deleteFile(file)
+	else
+		logstring = 'n-a'
+	end
+rescue => logstring
+ensure
+    Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+end
+
+## wrapping a Mcmlln::Tools method in a new method for this script; to return a result for json_logfile
+def deleteLockfileifExists(final_dir, logkey='')
+  donedir_lockfile_pathroot = File.join(final_dir, "layout", "lockfile_*.txt")
   if !Dir.glob(donedir_lockfile_pathroot).empty?
 		Mcmlln::Tools.deleteFile(Dir.glob(donedir_lockfile_pathroot)[0])
 	else
@@ -69,7 +83,7 @@ deleteFileifExists(Bkmkr::Project.input_file, 'delete_input_file')
 
 deleteFileifExists(Bkmkr::Paths.alert, 'delete_alert_file')
 
-deleteFileifExists('delete_final_dir_lockfile')
+deleteLockfileifExists(final_dir, 'delete_final_dir_lockfile')
 
 # ---------------------- LOGGING
 # Write json log:

--- a/core/cleanup/cleanup.rb
+++ b/core/cleanup/cleanup.rb
@@ -4,6 +4,7 @@ require_relative '../metadata.rb'
 # ---------------------- VARIABLES
 local_log_hash, @log_hash = Bkmkr::Paths.setLocalLoghash
 
+unused_submitted_dir = File.join(Bkmkr::Paths.done_dir, "Metadata.pisbn", "unused_submitted_files")
 
 # ---------------------- METHODS
 def readConfigJson(logkey='')
@@ -13,6 +14,22 @@ rescue => logstring
   return {}
 ensure
   Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+end
+
+def cpUnusedSubmitted(src, dest, logkey='')
+  files = Dir.entries(src) - ['..', '.', '.DS_Store']
+  unless files.empty?
+    unless Dir.exist?(dest)
+      Mcmlln::Tools.makeDir(dest)
+    end
+    Mcmlln::Tools.copyAllFiles(src, dest)
+    logstring = "moved #{files.length} files to done/unused_submitted_dir"
+  else
+    logstring = 'n-a'
+  end
+rescue => logstring
+ensure
+    Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
 end
 
 ## wrapping a Mcmlln::Tools method in a new method for this script; to return a result for json_logfile
@@ -40,6 +57,9 @@ data_hash = readConfigJson('read_config_json')
 #local definition(s) based on config.json
 project_dir = data_hash['project']
 stage_dir = data_hash['stage']
+
+# move any remaining files from submitted-tmpdir to done dir
+cpUnusedSubmitted(Bkmkr::Paths.project_tmp_dir_submitted, unused_submitted_dir, 'cp_unused_submitted_items_to_donedir')
 
 # Delete all the working files and dirs
 deleteProjectTmpDir('delete_project_tmp_folder')

--- a/core/cleanup/cleanup.rb
+++ b/core/cleanup/cleanup.rb
@@ -4,7 +4,7 @@ require_relative '../metadata.rb'
 # ---------------------- VARIABLES
 local_log_hash, @log_hash = Bkmkr::Paths.setLocalLoghash
 
-unused_submitted_dir = File.join(Bkmkr::Paths.done_dir, "Metadata.pisbn", "unused_submitted_files")
+unused_submitted_dir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "unused_submitted_files")
 
 # ---------------------- METHODS
 def readConfigJson(logkey='')

--- a/core/coverchecker/coverchecker.rb
+++ b/core/coverchecker/coverchecker.rb
@@ -10,10 +10,10 @@ local_log_hash, @log_hash = Bkmkr::Paths.setLocalLoghash
 cover = Metadata.frontcover
 
 # The directory where the cover was submitted
-coverdir = Bkmkr::Paths.submitted_images
+coverdir = Bkmkr::Paths.project_tmp_dir_submitted
 
 # the full path to the cover in tmp, including file name
-tmp_cover = File.join(Bkmkr::Paths.submitted_images, cover)
+tmp_cover = File.join(Bkmkr::Paths.project_tmp_dir_submitted, cover)
 
 # the full path to the cover in the archival location, including file name
 final_cover = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "cover", cover)

--- a/core/coverchecker/coverchecker.rb
+++ b/core/coverchecker/coverchecker.rb
@@ -16,10 +16,10 @@ coverdir = Bkmkr::Paths.project_tmp_dir_submitted
 tmp_cover = File.join(Bkmkr::Paths.project_tmp_dir_submitted, cover)
 
 # the full path to the cover in the archival location, including file name
-final_cover = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "cover", cover)
+final_cover = File.join(Metadata.final_dir, "cover", cover)
 
 # full path of cover error file
-cover_error = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "COVER_ERROR.txt")
+cover_error = File.join(Metadata.final_dir, "COVER_ERROR.txt")
 
 # An array listing all files in the submission dir
 files = Mcmlln::Tools.dirList(coverdir)

--- a/core/epubmaker/epubmaker.rb
+++ b/core/epubmaker/epubmaker.rb
@@ -55,16 +55,16 @@ epub_img_dir = File.join(Bkmkr::Paths.project_tmp_dir, "epubimg")
 csfilename = "#{Metadata.eisbn}_EPUB"
 
 # epub css file
-epub_css = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "layout", "epub.css")
+epub_css = File.join(Metadata.final_dir, "layout", "epub.css")
 
 # final image directory
-img_dir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
+img_dir = File.join(Metadata.final_dir, "images")
 
 # final converted epub
 final_epub = File.join(Bkmkr::Paths.project_tmp_dir, "#{csfilename}.epub")
 
 # final archive dir
-final_dir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn)
+final_dir = Metadata.final_dir
 
 # second epub conversion
 tmp_epub2 = File.join(Bkmkr::Paths.project_tmp_dir, "#{csfilename}.epub")
@@ -306,7 +306,7 @@ cover = data_hash['frontcover']
 
 # the path to the cover file
 unless data_hash['frontcover'].nil? or data_hash['frontcover'].empty? or !data_hash['frontcover']
-	final_cover = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "cover", cover)
+	final_cover = File.join(Metadata.final_dir, "cover", cover)
 else
 	final_cover = ""
 end
@@ -387,7 +387,7 @@ deleteTmpEpub(tmp_epub2, 'rm_tmp_epub_file')
 
 # ---------------------- LOGGING
 # epub file should exist in done dir
-if File.file?("#{Bkmkr::Paths.done_dir}/#{Metadata.pisbn}/#{csfilename}.epub")
+if File.file?("#{Metadata.final_dir}/#{csfilename}.epub")
 	test_epub_status = "pass: the EPUB was created successfully"
 else
 	test_epub_status = "FAIL: the EPUB was created successfully"

--- a/core/filearchive/filearchive.rb
+++ b/core/filearchive/filearchive.rb
@@ -9,21 +9,21 @@ local_log_hash, @log_hash = Bkmkr::Paths.setLocalLoghash
 # create the archival directory structure and copy xml and html there
 filetype = Bkmkr::Project.filename_split.split(".").pop
 
-final_dir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn)
+final_dir = File.join(Metadata.final_dir)
 
-final_dir_images = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
+final_dir_images = File.join(Metadata.final_dir, "images")
 
-final_dir_cover = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "cover")
+final_dir_cover = File.join(Metadata.final_dir, "cover")
 
-final_dir_layout = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "layout")
+final_dir_layout = File.join(Metadata.final_dir, "layout")
 
-final_manuscript = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "#{Metadata.pisbn}_MNU.#{filetype}")
+final_manuscript = File.join(Metadata.final_dir, "#{Metadata.pisbn}_MNU.#{filetype}")
 
-final_html = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "layout", "#{Metadata.pisbn}.html")
+final_html = File.join(Metadata.final_dir, "layout", "#{Metadata.pisbn}.html")
 
 tmp_config = File.join(Bkmkr::Paths.project_tmp_dir, "config.json")
 
-final_config = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "layout", "config.json")
+final_config = File.join(Metadata.final_dir, "layout", "config.json")
 
 # ---------------------- METHODS
 ## wrapping a Mcmlln::Tools method in a new method for this script; to return a result for json_logfile

--- a/core/header.rb
+++ b/core/header.rb
@@ -82,10 +82,34 @@ module Bkmkr
 			end
 		end
 
-		# Path to the temporary working directory
-		@@project_tmp_dir = File.join(tmp_dir, Project.filename)
+		# Path to the temporary working directory has to be calculated.. checking for highest increment present
+		# => the dir is actually created in tmparchive.rb (or rsuite equivalent (TK))
+		project_tmp_dir_base = File.join(tmp_dir, Project.filename)
+		if Project.filename.match(/_\d+$/)
+			# adding a hyphen as pre-suffix to filenames that happen to end in our std naming: '_\d'
+			projtmpdir_root = "#{project_tmp_dir_base}-_"
+		else
+			projtmpdir_root = "#{project_tmp_dir_base}_"
+		end
+		count = 1
+		project_tmp_dir = "#{projtmpdir_root}#{count}"
+		while Dir.exists?(project_tmp_dir)
+			count +=1
+			project_tmp_dir = "#{projtmpdir_root}#{count}"
+		end
+		# tmparchive loads header before the tmpdir has been created, so count is > by 1
+		if File.basename($0) != 'tmparchive.rb' && File.basename($0) != 'tmparchive_rsuite.rb'
+			project_tmp_dir = "#{projtmpdir_root}#{count-1}"
+		end
+
+		@@project_tmp_dir = project_tmp_dir
 		def self.project_tmp_dir
 			@@project_tmp_dir
+		end
+
+		@@project_tmp_dir_submitted = File.join(project_tmp_dir, "submitted_files")
+		def self.project_tmp_dir_submitted
+			@@project_tmp_dir_submitted
 		end
 
 		# Path to the images subdirectory of the temporary working directory

--- a/core/header.rb
+++ b/core/header.rb
@@ -99,7 +99,15 @@ module Bkmkr
 		end
 		# tmparchive loads header before the tmpdir has been created, so count is > by 1
 		if File.basename($0) != 'tmparchive.rb' && File.basename($0) != 'tmparchive_rsuite.rb'
-			project_tmp_dir = "#{projtmpdir_root}#{count-1}"
+			count -= 1
+			project_tmp_dir = "#{projtmpdir_root}#{count}"
+		end
+
+		# for use in naming done_dir lockfile
+		# @@unique_run_id = project_tmp_dir.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
+		@@unique_run_id = count
+		def self.unique_run_id
+			@@unique_run_id
 		end
 
 		@@project_tmp_dir = project_tmp_dir
@@ -150,6 +158,8 @@ module Bkmkr
 				Project.input_dir
 			end
 		end
+
+
 
 		# Full path to project log file
 		@@log_file = File.join(log_dir, "#{Project.filename}.txt")

--- a/core/imagechecker/imagechecker.rb
+++ b/core/imagechecker/imagechecker.rb
@@ -9,12 +9,12 @@ local_log_hash, @log_hash = Bkmkr::Paths.setLocalLoghash
 # The locations to check for images
 imagedir = Bkmkr::Paths.project_tmp_dir_submitted
 
-final_dir_images = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
+final_dir_images = File.join(Metadata.final_dir, "images")
 
-final_cover = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "cover", Metadata.frontcover)
+final_cover = File.join(Metadata.final_dir, "cover", Metadata.frontcover)
 
 # full path to the image error file
-image_error = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "IMAGE_ERROR.txt")
+image_error = File.join(Metadata.final_dir, "IMAGE_ERROR.txt")
 
 # ---------------------- METHODS
 ## wrapping a Mcmlln::Tools method in a new method for this script; to return a result for json_logfile

--- a/core/imagechecker/imagechecker.rb
+++ b/core/imagechecker/imagechecker.rb
@@ -7,7 +7,7 @@ require_relative '../metadata.rb'
 local_log_hash, @log_hash = Bkmkr::Paths.setLocalLoghash
 
 # The locations to check for images
-imagedir = Bkmkr::Paths.submitted_images
+imagedir = Bkmkr::Paths.project_tmp_dir_submitted
 
 final_dir_images = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
 

--- a/core/metadata.rb
+++ b/core/metadata.rb
@@ -196,9 +196,9 @@ class Metadata
     # write alertfile if we had to create an alternate final_dir
     if locked == true
       lock_alert_file = File.join(final_dir, "ERROR-Concurrent_Bookmaker_Runs.txt")
-      lockalert_text = 'A "done" folder already exists for this title, and appears to be in use.'\
-      'Wait 15 minutes and run this file again to ensure all resources are available.'\
-      'If you think you\'re getting this malert in error, contact workflows@macmillan.com'
+      lockalert_text = 'A "done" folder already exists for this title, and appears to be in use. '\
+      'Wait 15 minutes and run this file again to ensure all resources are available. '\
+      'If you think you\'re getting this alert in error, contact workflows@macmillan.com'
       writeFileWithContents(lock_alert_file, lockalert_text, log_hash, 'metadata.rb-writing_lock_alert_file')
     end
   rescue => logstring

--- a/core/metadata.rb
+++ b/core/metadata.rb
@@ -122,4 +122,152 @@ class Metadata
 			@@data_hash['podtitlepage']
 		end
 	end
+
+  # def self.final_dir
+  #   if Dir.exists?(File.join("#{Bkmkr::Paths.done_dir}","#{@@data_hash['printid']}_#{Bkmkr::Paths.unique_run_id}"))
+  #     File.join("#{Bkmkr::Paths.done_dir}","#{@@data_hash['printid']}_#{Bkmkr::Paths.unique_run_id}")
+  #   else
+  #     File.join("#{Bkmkr::Paths.done_dir}",@@data_hash['printid'])
+  #   end
+  # end
+
+  # if Dir.exists?(File.join("#{Bkmkr::Paths.done_dir}","#{@@data_hash['printid']}_#{Bkmkr::Paths.unique_run_id}"))
+  #   @@final_dir = File.join("#{Bkmkr::Paths.done_dir}","#{@@data_hash['printid']}_#{Bkmkr::Paths.unique_run_id}")
+  # else
+  #   @@final_dir = File.join("#{Bkmkr::Paths.done_dir}",@@data_hash['printid'])
+  # end
+  # def self.final_dir
+  #   @@final_dir
+  # end
+  #
+  # @@lockfile = File.join(@@final_dir, "layout", "lockfile_#{Bkmkr::Paths.unique_run_id}.txt")
+  # def self.lockfile
+  #   @@lockfile
+  # end
+
+  # # # # # # # METHODS for setting final_dir, lockfolder
+
+  ## wrapping a Mcmlln::Tools method in a new method for this script; to return a result for json_logfile
+  def makeFolder(path, logkey='')
+  # def self.makeFolder(path, logkey='')
+    unless Dir.exist?(path)
+      Mcmlln::Tools.makeDir(path)
+    else
+      logstring = 'n-a'
+    end
+  rescue => logstring
+  ensure
+    Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+  end
+
+  # def self.writeFileWithContents(file, filecontents, logkey='')
+  def writeFileWithContents(file, filecontents, logkey='')
+    Mcmlln::Tools.overwriteFile(file, filecontents)
+  rescue => logstring
+  ensure
+    Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+  end
+
+  ## wrapping a Mcmlln::Tools method in a new method for this script; to return a result for json_logfile
+  def deleteOldFinalDir(locked, dir, logkey='')
+  # def self.deleteOldFinalDir(locked, dir, logkey='')
+    if locked == true
+    	Mcmlln::Tools.deleteDir(dir)
+    else
+      logstring = 'n-a'
+    end
+  rescue => logstring
+  ensure
+      Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+  end
+
+  def makeLockFiles(final_dir, locked, project_tmpdir, logkey='')
+  # def self.makeLockFiles(final_dir, locked, project_tmpdir, logkey='')
+    timestamp = Time.now.strftime("%y%m%d-%H%M%S%1N") #timestamp to 10th of a second
+    lockfile_basename = "lockfile_#{timestamp}.txt"
+    tmpdir_lockfile = File.join(project_tmpdir, lockfile_basename)
+    donedir_lockfile = File.join(final_dir, "layout", "lockfile_#{timestamp}.txt")
+
+    # create & rm dirs as needed:
+    deleteOldFinalDir(locked, final_dir, 'remove_any_previous_alt_final_dir')
+    makeFolder(final_dir, 'create_final_dir')
+    makeFolder(File.join(final_dir, "layout"), 'create_final_dir_layout')
+
+    # make lockfile
+    writeFileWithContents(tmpdir_lockfile, Time.now.strftime("%y-%m-%s"), 'write_tmpdir_lockfile')
+    writeFileWithContents(donedir_lockfile, Time.now.strftime("%y-%m-%s"), 'write_donedir_lockfile')
+
+    # write alertfile if we had to create an alternate final_dir
+    if locked == true
+      lock_alert_file = File.join(final_dir, "ERROR-Concurrent_Bookmaker_Runs.txt")
+      lockalert_text = 'A "done" folder already exists for this title, and appears to be in use.'\
+      'Wait 15 minutes and run this file again to ensure all resources are available.'\
+      'If you think you\'re getting this malert in error, contact workflows@macmillan.com'
+      writeFileWithContents(lock_alert_file, lockalert_text, 'writing_lock_alert_file')
+    end
+  rescue => logstring
+  ensure
+    Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+  end
+
+  def setFinalDir(project_tmpdir, done_dir, pisbn, unique_run_id, logkey='')
+  # def self.setFinalDir(project_tmpdir, done_dir, pisbn, unique_run_id, logkey='')
+    locked = false
+    final_dir = File.join(done_dir, pisbn)
+    donedir_lockfile_pathroot = File.join(final_dir, "layout", "lockfile_*.txt")
+    # test if default final_dir is already locked
+    if !Dir.glob(donedir_lockfile_pathroot).empty?
+      strange_lockfile = Dir.glob(donedir_lockfile_pathroot)[0]
+      # wait_increment = 60 # < production
+      wait_increment = 1 # < debug/test
+      max_increments = 15
+      n = 0
+      # wait and see if final_dir lockfile is deleted
+      while File.exist?(strange_lockfile) and n <= max_increments
+        sleep(wait_increment)
+        n += 1
+      end
+      # check again after whileloop
+      if File.exist?(strange_lockfile) # still locked :(
+        final_dir = File.join(done_dir, "#{pisbn}_#{unique_run_id}")
+        locked = true
+        logstring = "final_dir locked for #{n} minutes, setting new one: #{final_dir}"
+      else
+        logstring = "existing final_dir was locked, unlocked after #{n} minutes"
+      end
+    else
+      # final_dir not locked at all!
+      logstring = "no pre-existing final_dir, or existing one not locked"
+    end
+    return final_dir, locked
+  rescue => logstring
+  ensure
+    return final_dir, false
+    Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+  end
+
+  def self.getFinalDir(project_tmpdir, done_dir, pisbn, unique_run_id, logkey='')
+    tmpdir_lockfile_pathroot = File.join(project_tmpdir, "lockfile_*.txt")
+    if Dir.glob(tmpdir_lockfile_pathroot).empty?
+      # lockfiles aren't setup! do it!
+      final_dir, locked = setFinalDir(project_tmpdir, done_dir, pisbn, unique_run_id, 'set_final_dir')
+      # make Lockfiles, error texts, etc!
+      makeLockFiles(final_dir, locked, project_tmpdir, 'make_lockfiles')
+    else
+      tmpdir_lockfile = Dir.glob(tmpdir_lockfile_pathroot)[0]
+      tmpdir_lockfile_basename = tmpdir_lockfile.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
+      final_dir_lockfile = Dir.glob(File.join(done_dir,"#{pisbn}*","layout",tmpdir_lockfile_basename))[0]
+      final_dir = final_dir_lockfile.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact))[0...-2].join(File::SEPARATOR)
+    end
+    return final_dir
+  rescue => logstring
+  ensure
+    return ''
+    Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+  end
+
+  @@final_dir = getFinalDir(Bkmkr::Paths.project_tmp_dir, Bkmkr::Paths.done_dir, @@data_hash['printid'], Bkmkr::Paths.unique_run_id)
+  def self.final_dir
+    @@final_dir
+  end
 end

--- a/core/metadata.rb
+++ b/core/metadata.rb
@@ -123,33 +123,33 @@ class Metadata
 		end
 	end
 
-  # def self.final_dir
-  #   if Dir.exists?(File.join("#{Bkmkr::Paths.done_dir}","#{@@data_hash['printid']}_#{Bkmkr::Paths.unique_run_id}"))
-  #     File.join("#{Bkmkr::Paths.done_dir}","#{@@data_hash['printid']}_#{Bkmkr::Paths.unique_run_id}")
-  #   else
-  #     File.join("#{Bkmkr::Paths.done_dir}",@@data_hash['printid'])
-  #   end
-  # end
-
-  # if Dir.exists?(File.join("#{Bkmkr::Paths.done_dir}","#{@@data_hash['printid']}_#{Bkmkr::Paths.unique_run_id}"))
-  #   @@final_dir = File.join("#{Bkmkr::Paths.done_dir}","#{@@data_hash['printid']}_#{Bkmkr::Paths.unique_run_id}")
-  # else
-  #   @@final_dir = File.join("#{Bkmkr::Paths.done_dir}",@@data_hash['printid'])
-  # end
-  # def self.final_dir
-  #   @@final_dir
-  # end
-  #
-  # @@lockfile = File.join(@@final_dir, "layout", "lockfile_#{Bkmkr::Paths.unique_run_id}.txt")
-  # def self.lockfile
-  #   @@lockfile
-  # end
+  def self.final_dir
+    # set a default final_dir
+    final_dir = File.join(Bkmkr::Paths.done_dir, @@data_hash['printid'])
+    # now find true final_dir based on lockfiles
+    tmpdir_lockfile_pathroot = File.join(Bkmkr::Paths.project_tmp_dir, "lockfile_*.txt")
+    puts "check 1"
+    if !Dir.glob(tmpdir_lockfile_pathroot).empty?
+      # get lockfile
+      tmpdir_lockfile = Dir.glob(tmpdir_lockfile_pathroot)[0]
+      tmpdir_lockfile_basename = tmpdir_lockfile.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
+      # look for matching lockfile in Done dirs
+      final_dir_lockfile_arr = Dir.glob(File.join(Bkmkr::Paths.done_dir,"#{@@data_hash['printid']}*","layout",tmpdir_lockfile_basename))
+      puts "check 2"
+      if !final_dir_lockfile_arr.empty?
+        final_dir_lockfile = final_dir_lockfile_arr[0]
+        final_dir = final_dir_lockfile.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact))[0...-2].join(File::SEPARATOR)
+        puts "check 3"
+      end
+    end
+    puts "final_dir: #{final_dir}"
+    final_dir
+  end
 
   # # # # # # # METHODS for setting final_dir, lockfolder
 
   ## wrapping a Mcmlln::Tools method in a new method for this script; to return a result for json_logfile
-  def makeFolder(path, logkey='')
-  # def self.makeFolder(path, logkey='')
+  def self.makeFolder(path, log_hash, logkey='')
     unless Dir.exist?(path)
       Mcmlln::Tools.makeDir(path)
     else
@@ -157,45 +157,45 @@ class Metadata
     end
   rescue => logstring
   ensure
-    Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+    Mcmlln::Tools.logtoJson(log_hash, logkey, logstring)
+    return log_hash
   end
 
-  # def self.writeFileWithContents(file, filecontents, logkey='')
-  def writeFileWithContents(file, filecontents, logkey='')
+  def self.writeFileWithContents(file, filecontents, log_hash, logkey='')
     Mcmlln::Tools.overwriteFile(file, filecontents)
   rescue => logstring
   ensure
-    Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+    Mcmlln::Tools.logtoJson(log_hash, logkey, logstring)
+    return log_hash
   end
 
   ## wrapping a Mcmlln::Tools method in a new method for this script; to return a result for json_logfile
-  def deleteOldFinalDir(locked, dir, logkey='')
-  # def self.deleteOldFinalDir(locked, dir, logkey='')
+  def self.deleteOldFinalDir(locked, dir, log_hash, logkey='')
     if locked == true
-    	Mcmlln::Tools.deleteDir(dir)
+      Mcmlln::Tools.deleteDir(dir)
     else
       logstring = 'n-a'
     end
   rescue => logstring
   ensure
-      Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+    Mcmlln::Tools.logtoJson(log_hash, logkey, logstring)
+    return log_hash
   end
 
-  def makeLockFiles(final_dir, locked, project_tmpdir, logkey='')
-  # def self.makeLockFiles(final_dir, locked, project_tmpdir, logkey='')
+  def self.makeLockFiles(final_dir, locked, project_tmpdir, log_hash, logkey='')
     timestamp = Time.now.strftime("%y%m%d-%H%M%S%1N") #timestamp to 10th of a second
     lockfile_basename = "lockfile_#{timestamp}.txt"
     tmpdir_lockfile = File.join(project_tmpdir, lockfile_basename)
     donedir_lockfile = File.join(final_dir, "layout", "lockfile_#{timestamp}.txt")
 
     # create & rm dirs as needed:
-    deleteOldFinalDir(locked, final_dir, 'remove_any_previous_alt_final_dir')
-    makeFolder(final_dir, 'create_final_dir')
-    makeFolder(File.join(final_dir, "layout"), 'create_final_dir_layout')
+    deleteOldFinalDir(locked, final_dir, log_hash, 'metadata.rb-remove_any_previous_alt_final_dir')
+    makeFolder(final_dir, log_hash, 'metadata.rb-create_final_dir')
+    makeFolder(File.join(final_dir, "layout"), log_hash, 'metadata.rb-create_final_dir_layout')
 
     # make lockfile
-    writeFileWithContents(tmpdir_lockfile, Time.now.strftime("%y-%m-%s"), 'write_tmpdir_lockfile')
-    writeFileWithContents(donedir_lockfile, Time.now.strftime("%y-%m-%s"), 'write_donedir_lockfile')
+    writeFileWithContents(tmpdir_lockfile, timestamp, log_hash, 'metadata.rb-write_tmpdir_lockfile')
+    writeFileWithContents(donedir_lockfile, timestamp, log_hash, 'metadata.rb-write_donedir_lockfile')
 
     # write alertfile if we had to create an alternate final_dir
     if locked == true
@@ -203,27 +203,29 @@ class Metadata
       lockalert_text = 'A "done" folder already exists for this title, and appears to be in use.'\
       'Wait 15 minutes and run this file again to ensure all resources are available.'\
       'If you think you\'re getting this malert in error, contact workflows@macmillan.com'
-      writeFileWithContents(lock_alert_file, lockalert_text, 'writing_lock_alert_file')
+      writeFileWithContents(lock_alert_file, lockalert_text, log_hash, 'metadata.rb-writing_lock_alert_file')
     end
   rescue => logstring
   ensure
-    Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+    Mcmlln::Tools.logtoJson(log_hash, logkey, logstring)
+    return log_hash
   end
 
-  def setFinalDir(project_tmpdir, done_dir, pisbn, unique_run_id, logkey='')
-  # def self.setFinalDir(project_tmpdir, done_dir, pisbn, unique_run_id, logkey='')
+  def self.setFinalDir(project_tmpdir, done_dir, pisbn, unique_run_id, log_hash, logkey='')
     locked = false
     final_dir = File.join(done_dir, pisbn)
     donedir_lockfile_pathroot = File.join(final_dir, "layout", "lockfile_*.txt")
     # test if default final_dir is already locked
     if !Dir.glob(donedir_lockfile_pathroot).empty?
       strange_lockfile = Dir.glob(donedir_lockfile_pathroot)[0]
-      # wait_increment = 60 # < production
-      wait_increment = 1 # < debug/test
+      wait_increment = 60 # < production
+      if $op_system == "mac"
+        wait_increment = 1 # < debug/test
+      end
       max_increments = 15
       n = 0
       # wait and see if final_dir lockfile is deleted
-      while File.exist?(strange_lockfile) and n <= max_increments
+      while File.exist?(strange_lockfile) and n < max_increments
         sleep(wait_increment)
         n += 1
       end
@@ -239,35 +241,40 @@ class Metadata
       # final_dir not locked at all!
       logstring = "no pre-existing final_dir, or existing one not locked"
     end
-    return final_dir, locked
   rescue => logstring
+    final_dir = ''
+    locked = false
   ensure
-    return final_dir, false
-    Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+    Mcmlln::Tools.logtoJson(log_hash, logkey, logstring)
+    return final_dir, locked, log_hash
   end
 
-  def self.getFinalDir(project_tmpdir, done_dir, pisbn, unique_run_id, logkey='')
+  def self.setupFinalDir(project_tmpdir, done_dir, pisbn, unique_run_id, log_hash, logkey='')
     tmpdir_lockfile_pathroot = File.join(project_tmpdir, "lockfile_*.txt")
     if Dir.glob(tmpdir_lockfile_pathroot).empty?
       # lockfiles aren't setup! do it!
-      final_dir, locked = setFinalDir(project_tmpdir, done_dir, pisbn, unique_run_id, 'set_final_dir')
+      final_dir, locked = setFinalDir(project_tmpdir, done_dir, pisbn, unique_run_id, log_hash, 'metadata.rb-set_final_dir')
       # make Lockfiles, error texts, etc!
-      makeLockFiles(final_dir, locked, project_tmpdir, 'make_lockfiles')
+      makeLockFiles(final_dir, locked, project_tmpdir, log_hash, 'metadata.rb-make_lockfiles')
     else
       tmpdir_lockfile = Dir.glob(tmpdir_lockfile_pathroot)[0]
       tmpdir_lockfile_basename = tmpdir_lockfile.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
-      final_dir_lockfile = Dir.glob(File.join(done_dir,"#{pisbn}*","layout",tmpdir_lockfile_basename))[0]
+      final_dir_lockfile_arr = Dir.glob(File.join(done_dir,"#{pisbn}*","layout",tmpdir_lockfile_basename))
+      if final_dir_lockfile_arr.empty?
+        # somehow done_dir got deleted (likely in course of troubleshooting). Reset, make new lockfiles
+        Mcmlln::Tools.deleteFile(tmpdir_lockfile)
+        final_dir = File.join(done_dir, pisbn)
+        makeLockFiles(final_dir, false, project_tmpdir, log_hash, 'metadata.rb-make_lockfiles')
+      else
+        final_dir_lockfile = final_dir_lockfile_arr[0]
+        final_dir = final_dir_lockfile.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact))[0...-2].join(File::SEPARATOR)
+      end
       final_dir = final_dir_lockfile.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact))[0...-2].join(File::SEPARATOR)
     end
-    return final_dir
   rescue => logstring
+    final_dir = ''
   ensure
-    return ''
-    Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
-  end
-
-  @@final_dir = getFinalDir(Bkmkr::Paths.project_tmp_dir, Bkmkr::Paths.done_dir, @@data_hash['printid'], Bkmkr::Paths.unique_run_id)
-  def self.final_dir
-    @@final_dir
+    Mcmlln::Tools.logtoJson(log_hash, logkey, logstring)
+    return final_dir, log_hash
   end
 end

--- a/core/metadata.rb
+++ b/core/metadata.rb
@@ -128,21 +128,17 @@ class Metadata
     final_dir = File.join(Bkmkr::Paths.done_dir, @@data_hash['printid'])
     # now find true final_dir based on lockfiles
     tmpdir_lockfile_pathroot = File.join(Bkmkr::Paths.project_tmp_dir, "lockfile_*.txt")
-    puts "check 1"
     if !Dir.glob(tmpdir_lockfile_pathroot).empty?
       # get lockfile
       tmpdir_lockfile = Dir.glob(tmpdir_lockfile_pathroot)[0]
       tmpdir_lockfile_basename = tmpdir_lockfile.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
       # look for matching lockfile in Done dirs
       final_dir_lockfile_arr = Dir.glob(File.join(Bkmkr::Paths.done_dir,"#{@@data_hash['printid']}*","layout",tmpdir_lockfile_basename))
-      puts "check 2"
       if !final_dir_lockfile_arr.empty?
         final_dir_lockfile = final_dir_lockfile_arr[0]
         final_dir = final_dir_lockfile.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact))[0...-2].join(File::SEPARATOR)
-        puts "check 3"
       end
     end
-    puts "final_dir: #{final_dir}"
     final_dir
   end
 

--- a/core/pdfmaker/pdfmaker.rb
+++ b/core/pdfmaker/pdfmaker.rb
@@ -21,7 +21,7 @@ cssfile = File.join(Bkmkr::Project.working_dir, "done", Metadata.pisbn, "layout"
 
 tmppdf = File.join(Bkmkr::Paths.project_tmp_dir, "#{Metadata.pisbn}.pdf")
 
-finalpdf = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "#{Metadata.pisbn}_POD.pdf")
+finalpdf = File.join(Metadata.final_dir, "#{Metadata.pisbn}_POD.pdf")
 
 watermark_css = File.join(Bkmkr::Paths.scripts_dir, "bookmaker_assets", "pdfmaker", "css", "generic", "watermark.css")
 

--- a/core/pdfmaker/pdfmaker.rb
+++ b/core/pdfmaker/pdfmaker.rb
@@ -17,7 +17,7 @@ pdf_tmp_html = File.join(Bkmkr::Paths.project_tmp_dir, "pdf_tmp.html")
 
 testing_value_file = File.join(Bkmkr::Paths.resource_dir, "staging.txt")
 
-cssfile = File.join(Bkmkr::Project.working_dir, "done", Metadata.pisbn, "layout", "pdf.css")
+cssfile = File.join(Metadata.final_dir, "layout", "pdf.css")
 
 tmppdf = File.join(Bkmkr::Paths.project_tmp_dir, "#{Metadata.pisbn}.pdf")
 

--- a/core/stylesheets/stylesheets.rb
+++ b/core/stylesheets/stylesheets.rb
@@ -115,7 +115,7 @@ end
 
 def evalOneoffs(file, path, logkey='')
 	tmp_layout_dir = File.join(Bkmkr::Project.working_dir, "done", Metadata.pisbn, "layout")
-	oneoffcss_new = File.join(Bkmkr::Paths.submitted_images, file)
+	oneoffcss_new = File.join(Bkmkr::Paths.project_tmp_dir_submitted, file)
 	oneoffcss_pickup = File.join(tmp_layout_dir, file)
 
 	if File.file?(oneoffcss_new)
@@ -211,8 +211,8 @@ deleteLastRunCss(tmp_pdf_css, 'delete_existing_tmp_pdf_css')
 deleteLastRunCss(tmp_epub_css, 'delete_existing_tmp_epub_css')
 
 # look for custom css in submitted_images dir
-find_pdf_css_file = File.join(Bkmkr::Paths.submitted_images, Metadata.printcss)
-find_epub_css_file = File.join(Bkmkr::Paths.submitted_images, Metadata.epubcss)
+find_pdf_css_file = File.join(Bkmkr::Paths.project_tmp_dir_submitted, Metadata.printcss)
+find_epub_css_file = File.join(Bkmkr::Paths.project_tmp_dir_submitted, Metadata.epubcss)
 
 # so we get logging re: evalImports even if it's not run
 @log_hash['evalImports_pdf_css-metadata'] = 'n-a'

--- a/core/stylesheets/stylesheets.rb
+++ b/core/stylesheets/stylesheets.rb
@@ -6,7 +6,7 @@ require_relative '../metadata.rb'
 # ---------------------- VARIABLES
 local_log_hash, @log_hash = Bkmkr::Paths.setLocalLoghash
 
-tmp_layout_dir = File.join(Bkmkr::Project.working_dir, "done", Metadata.pisbn, "layout")
+tmp_layout_dir = File.join(Metadata.final_dir, "layout")
 
 tmp_pdf_css = File.join(tmp_layout_dir, "pdf.css")
 
@@ -114,7 +114,7 @@ ensure
 end
 
 def evalOneoffs(file, path, logkey='')
-	tmp_layout_dir = File.join(Bkmkr::Project.working_dir, "done", Metadata.pisbn, "layout")
+	tmp_layout_dir = File.join(Metadata.final_dir, "layout")
 	oneoffcss_new = File.join(Bkmkr::Paths.project_tmp_dir_submitted, file)
 	oneoffcss_pickup = File.join(tmp_layout_dir, file)
 

--- a/core/tmparchive/tmparchive.rb
+++ b/core/tmparchive/tmparchive.rb
@@ -116,7 +116,6 @@ filecontents = "The conversion processor is currently running. Please do not sub
 
 writeAlertFile(filecontents, 'write_alert_file')
 
-puts "current projecttmpdir is: (bottom tmp)", Bkmkr::Paths.project_tmp_dir
 # ---------------------- LOGGING
 # Write json log:
 Mcmlln::Tools.logtoJson(@log_hash, 'completed', Time.now)

--- a/core/tmparchive/tmparchive.rb
+++ b/core/tmparchive/tmparchive.rb
@@ -103,10 +103,10 @@ makeFolder(Bkmkr::Paths.project_tmp_dir_img, 'project_tmp_img_folder_created')
 
 makeFolder(Bkmkr::Paths.project_tmp_dir_submitted, 'project_tmp_submitted_folder created')
 
+mvInputConfigFile(input_config, tmp_config, 'moved_input_config_file')
+
 # Rename and move input files to tmp folder to eliminate possibility of overwriting
 copyInputFile('copy_input_file')
-
-mvInputConfigFile(input_config, tmp_config, 'moved_input_config_file')
 
 # move all submitted files to project_tmp_dir_submitted
 # => except input file and config.json (already moved above)


### PR DESCRIPTION
1 of a set of 5 PR's to handle concurrent bookmaker runs, both with the tmpdir & the done_dir.
Straightforward unless a 'locked' done dir for the exact same ISBN exists, then it retries every minute for 15 minutes, then spawns a new done_dir with an error.txt in the root.
Repos affected:
bookmaker
bookmaker_addons (https://github.com/macmillanpublishers/bookmaker_addons/pull/203)
bookmaker_connectors
pitstop_watch
covermaker